### PR TITLE
Moved baselifespan increase to Method

### DIFF
--- a/src/app/game-state/character.ts
+++ b/src/app/game-state/character.ts
@@ -240,11 +240,7 @@ export class Character {
 
     // age in days
     this.age = INITIAL_AGE;
-    this.baseLifespan += 1; //bonus day just for doing another reincarnation cycle
-    if (this.baseLifespan > 25550){
-      // cap base at 70 years
-      this.baseLifespan = 25550;
-    }
+    this.increaseBaseLifespan(1, 70); //bonus day just for doing another reincarnation cycle, cap base at 70 years
     this.foodLifespan = 0;
     this.alchemyLifespan = 0;
     this.spiritualityLifespan = 0;
@@ -385,6 +381,22 @@ export class Character {
     }
     this.attributes[attribute].value += increaseAmount;
     return increaseAmount;
+  }
+
+  /**increase in days 
+   * 
+   * limit in years
+   * 
+   * returns false if limit is reached.
+  */
+  increaseBaseLifespan(increase: number, limit: number): boolean {
+    if (this.baseLifespan + increase < limit * 365){
+      this.baseLifespan += increase;
+      return true;
+    } else if (this.baseLifespan < limit * 365) {
+      this.baseLifespan = limit * 365;
+    }
+    return false;
   }
 
   checkOverage(){


### PR DESCRIPTION
This move allows other interesting means of increasing the base lifespan that don't rely on 15k deaths, and allows for different limits to be easily set later if desired.