### PR TITLE
Auto-buy reserve options

### DIFF
--- a/src/app/game-state/home.service.ts
+++ b/src/app/game-state/home.service.ts
@@ -62,6 +62,8 @@ export interface HomeProperties {
   autoBuyFurniture: FurnitureSlots,
   autoFieldUnlocked: boolean,
   autoFieldLimit: number,
+  useAutoBuyReserve: boolean,
+  autoBuyReserveAmount: number,
   nextHomeCostReduction: number,
   houseBuildingProgress: number,
   upgrading: boolean,
@@ -88,6 +90,8 @@ export class HomeService {
   }
   autoFieldUnlocked: boolean = false;
   autoFieldLimit: number = 0;
+  useAutoBuyReserve: boolean = false;
+  autoBuyReserveAmount: number = 0;
   land: number;
   landPrice: number;
   fields: Field[] = [];
@@ -509,6 +513,8 @@ export class HomeService {
       autoBuyFurnitureUnlocked: this.autoBuyFurnitureUnlocked,
       autoBuyFurniture: this.autoBuyFurniture,
       autoFieldUnlocked: this.autoFieldUnlocked,
+      useAutoBuyReserve: this.useAutoBuyReserve,
+      autoBuyReserveAmount: this.autoBuyReserveAmount,
       autoFieldLimit: this.autoFieldLimit,
       nextHomeCostReduction: this.nextHomeCostReduction,
       houseBuildingProgress: this.houseBuildingProgress,
@@ -533,6 +539,8 @@ export class HomeService {
     this.autoBuyFurniture = properties.autoBuyFurniture || false;
     this.autoFieldUnlocked = properties.autoFieldUnlocked || false;
     this.autoFieldLimit = properties.autoFieldLimit || 0;
+    this.useAutoBuyReserve = properties.useAutoBuyReserve || false;
+    this.autoBuyReserveAmount = properties.autoBuyReserveAmount || 0;
     this.nextHomeCostReduction = properties.nextHomeCostReduction || 0;
     this.houseBuildingProgress = properties.houseBuildingProgress || 1;
     this.upgrading = properties.upgrading || false;
@@ -698,7 +706,8 @@ export class HomeService {
   }
 
   autoBuy(){
-    let priceBuffer = (this.home.costPerDay + 1) * 10; // Ten days, by popular request.
+    // Use auto-buy reserve amount if enabled in settings, otherwise default to 10 days living expenses (food + lodging)
+    let priceBuffer = this.useAutoBuyReserve ? this.autoBuyReserveAmount : (this.home.costPerDay + 1) * 10;
     if (this.autoBuyHomeUnlocked && this.homeValue < this.autoBuyHomeLimit){
       // Don't buy land while upgrading.
       if (!this.upgrading){

--- a/src/app/options-modal/options-modal.component.html
+++ b/src/app/options-modal/options-modal.component.html
@@ -22,6 +22,14 @@
       </select>
     </span>
   </div>
+  <div *ngIf="homeService.autoBuyLandUnlocked || homeService.autoBuyHomeUnlocked || homeService.autoBuyFurnitureUnlocked" class="optionField">
+    <span>
+      <input type="checkbox" (change)="useAutoBuyReserveChanged($event)"
+        id="useAutoBuyReserve"  [checked]="homeService.useAutoBuyReserve"/>
+        <label for="useAutoBuyReserve">Auto-buying should always reserve <input value="{{homeService.autoBuyReserveAmount}}" type="number" class="inputBox" (change)="autoBuyReserveAmountChanged($event)"/> taels</label>
+    </span>
+  </div>
+
   <div *ngIf="inventoryService.autoequipBestArmor || inventoryService.autoequipBestWeapon"  class="optionField">
     <span>
       <input type="checkbox" (change)="autoequipEnableChange($event)"

--- a/src/app/options-modal/options-modal.component.ts
+++ b/src/app/options-modal/options-modal.component.ts
@@ -30,7 +30,14 @@ export class OptionsModalComponent {
     if (!(event.target instanceof HTMLSelectElement)) return;
     this.homeService.autoBuyHomeLimit = parseInt(event.target.value);
   }
-
+  useAutoBuyReserveChanged(event: Event){
+    if (!(event.target instanceof HTMLInputElement)) return;
+    this.homeService.useAutoBuyReserve = event.target.checked;
+  }
+  autoBuyReserveAmountChanged(event: Event){
+    if (!(event.target instanceof HTMLInputElement)) return;
+    this.homeService.autoBuyReserveAmount = parseInt(event.target.value);
+  }
   autoBalanceUseChanged(event: Event, balanceItem: BalanceItem){
     if (!(event.target instanceof HTMLInputElement)) return;
     balanceItem.useNumber = parseInt(event.target.value);


### PR DESCRIPTION
<img width="481" alt="image" src="https://user-images.githubusercontent.com/109362801/179276288-e6d6cbdb-927b-4928-8b3c-34ff4e0dbf2d.png">
<img width="485" alt="image" src="https://user-images.githubusercontent.com/109362801/179276314-738be8ab-616e-41c5-a0a6-03db3c272263.png">

Adds a checkbox to enable the static auto-buy reserve, and an input element to input the amount to be reserved. If the box is unchecked, the reserve amount is ignored and 10 * daily expenses is used. If checked, it uses the input instead of the base reserve amount.