### PR TITLE
#23 Pause on death should stop without starting the next life

### DIFF
--- a/src/app/game-state/main-loop.service.ts
+++ b/src/app/game-state/main-loop.service.ts
@@ -100,7 +100,11 @@ export class MainLoopService {
           this.tickCount++;
           if (this.tickCount >= this.tickDivider){
             this.tickCount = 0;
-            this.tick();
+            if (this.pause) {
+              this.bankedTicks++;
+            } else {
+              this.tick();
+            }
           }
         }
       }


### PR DESCRIPTION
Stop death consumning ticks of the next life by:
 - During the iteration of the ticks in main loop service if the game is paused during a tick, the nexts are not executed and saved in the banked ticks instead.
 - During the reincarnation in character service moving the actual reincarnation of the player to the next tick for stopping the next observables called during this tick of executing.