### PR TITLE
Shift Click when adding activities to start at 10

### DIFF
--- a/src/app/activity-panel/activity-panel.component.html
+++ b/src/app/activity-panel/activity-panel.component.html
@@ -10,7 +10,10 @@
       <tr *ngIf="(activity.unlocked)" draggable="true" (dragstart)="drag(activity, $event)">
         <td>
           <span class="noWrap">
-            <button (click)="onClick(activity)" tooltip="Add this activity to the bottom of your queue. Shift-click to start at 10 days.">{{activity.name[activity.level]}}</button>
+            <button (click)="onClick(activity, $event)" 
+                    tooltip="Add this activity to the bottom of your queue. Shift-click to start at 10 days.">
+              {{activity.name[activity.level]}}
+            </button>
             <mat-icon *ngIf="activity.skipApprenticeshipLevel > 0"
               tooltip="This activity requires that you go through an apprenticeship. You can only do one apprenticeship in each lifetime, so choose carefully what trade you want to learn. Once you've started, other trades may be closed off until your next life.">
               model_training

--- a/src/app/activity-panel/activity-panel.component.html
+++ b/src/app/activity-panel/activity-panel.component.html
@@ -10,7 +10,7 @@
       <tr *ngIf="(activity.unlocked)" draggable="true" (dragstart)="drag(activity, $event)">
         <td>
           <span class="noWrap">
-            <button (click)="onClick(activity)">{{activity.name[activity.level]}}</button>
+            <button (click)="onClick(activity)" tooltip="Add this activity to the bottom of your queue. Shift-click to start at 10 days.">{{activity.name[activity.level]}}</button>
             <mat-icon *ngIf="activity.skipApprenticeshipLevel > 0"
               tooltip="This activity requires that you go through an apprenticeship. You can only do one apprenticeship in each lifetime, so choose carefully what trade you want to learn. Once you've started, other trades may be closed off until your next life.">
               model_training

--- a/src/app/activity-panel/activity-panel.component.html
+++ b/src/app/activity-panel/activity-panel.component.html
@@ -11,7 +11,7 @@
         <td>
           <span class="noWrap">
             <button (click)="onClick(activity, $event)" 
-                    tooltip="Add this activity to the bottom of your queue. Shift-click to start at 10 days.">
+                    tooltip="Add this activity to your schedule. Shift click to also repeat it for 10 days.">
               {{activity.name[activity.level]}}
             </button>
             <mat-icon *ngIf="activity.skipApprenticeshipLevel > 0"

--- a/src/app/activity-panel/activity-panel.component.ts
+++ b/src/app/activity-panel/activity-panel.component.ts
@@ -25,7 +25,7 @@ export class ActivityPanelComponent {
   onClick(activity: Activity): void {
     this.activityService.activityLoop.push({
       activity: activity.activityType,
-      repeatTimes: 1
+      repeatTimes: event.shiftKey ? 10 : 1
     });
   }
 

--- a/src/app/activity-panel/activity-panel.component.ts
+++ b/src/app/activity-panel/activity-panel.component.ts
@@ -22,7 +22,7 @@ export class ActivityPanelComponent {
     this.character = characterService.characterState;
   }
 
-  onClick(activity: Activity): void {
+  onClick(activity: Activity, event: MouseEvent): void {
     this.activityService.activityLoop.push({
       activity: activity.activityType,
       repeatTimes: event.shiftKey ? 10 : 1


### PR DESCRIPTION
This allows the user to Shift Click on activities to add them with 10 days to start with, instead of just the base 1.