### PR TITLE
Always keep header and footer visible on schedule

### DIFF
--- a/src/app/app.component.less
+++ b/src/app/app.component.less
@@ -78,13 +78,13 @@
 }
 
 .timePanel {
-    flex: 1 1 auto;
+    flex: 1 1 50%;
     overflow: auto;
     margin-bottom: 0 !important;
 }
 
 .attributesPanel {
-    flex: 1 1 auto;
+    flex: 1 1 50%;
     overflow: auto;
     margin-top: 0 !important;
     margin-bottom: 0 !important;

--- a/src/app/time-panel/time-panel.component.html
+++ b/src/app/time-panel/time-panel.component.html
@@ -35,56 +35,59 @@
       <label for="useSavedTicks">Use banked time to accelerate reality. {{mainLoopService.bankedTicks | number: '1.0-0'}} time ticks left.</label>
     </h6>
   </h3>
-  <table>
-    <tr *ngFor="let entry of activityService.activityLoop; let indexOfelement=index;"
-      draggable="true" (dragover)="allowDrop($event)" (drop)="drop(indexOfelement, $event)" (dragstart)="drag(indexOfelement, $event)">
-      <td [ngClass]="{'currentRow': indexOfelement === activityService.currentIndex}">{{activityService.getActivityByType(entry.activity).name[activityService.getActivityByType(entry.activity).level]}} ({{entry.repeatTimes}} {{(entry.repeatTimes === 1) ? "day" : "days"}})</td>
-      <td [ngClass]="{'currentRow': indexOfelement === activityService.currentIndex}">
-        <div class="progress-bar">
-          <span 
-            [style.width.%]="100 * 
-              (indexOfelement !== activityService.currentIndex ? entry.repeatTimes : activityService.currentTickCount) / 
-              entry.repeatTimes">
-          </span>
-        </div>
-      </td>
-      <td [ngClass]="{'currentRow': indexOfelement === activityService.currentIndex}">
-        <mat-icon tooltip="Spend fewer days on this. Shift-click to remove 10 days." (click)="onMinusClick(entry, $event)" class="iconButton">remove</mat-icon>
-        <mat-icon tooltip="Spend more days on this. Shift-click to add 10 days." (click)="onPlusClick(entry, $event)" class="iconButton">add</mat-icon>
-        <mat-icon tooltip="Remove this activity from the schedule." (click)="onRemoveClick(entry)" class="iconButton">clear</mat-icon>
-      </td>
-    </tr>
-  </table>
+  <div class="overflow">
+    <table>
+      <tr *ngFor="let entry of activityService.activityLoop; let indexOfelement=index;"
+        draggable="true" (dragover)="allowDrop($event)" (drop)="drop(indexOfelement, $event)" (dragstart)="drag(indexOfelement, $event)">
+        <td [ngClass]="{'currentRow': indexOfelement === activityService.currentIndex}">{{activityService.getActivityByType(entry.activity).name[activityService.getActivityByType(entry.activity).level]}} ({{entry.repeatTimes}} {{(entry.repeatTimes === 1) ? "day" : "days"}})</td>
+        <td [ngClass]="{'currentRow': indexOfelement === activityService.currentIndex}">
+          <div class="progress-bar">
+            <span
+              [style.width.%]="100 *
+                (indexOfelement !== activityService.currentIndex ? entry.repeatTimes : activityService.currentTickCount) /
+                entry.repeatTimes">
+            </span>
+          </div>
+        </td>
+        <td [ngClass]="{'currentRow': indexOfelement === activityService.currentIndex}">
+          <mat-icon tooltip="Spend fewer days on this. Shift-click to remove 10 days." (click)="onMinusClick(entry, $event)" class="iconButton">remove</mat-icon>
+          <mat-icon tooltip="Spend more days on this. Shift-click to add 10 days." (click)="onPlusClick(entry, $event)" class="iconButton">add</mat-icon>
+          <mat-icon tooltip="Remove this activity from the schedule." (click)="onRemoveClick(entry)" class="iconButton">clear</mat-icon>
+        </td>
+      </tr>
+    </table>
 
-  <table *ngIf="characterService.characterState.manaUnlocked" class="spiritActivityPanel"
+    <table *ngIf="characterService.characterState.manaUnlocked" class="spiritActivityPanel"
     (drop)="spiritActivityDrop($event)" (dragover)="allowDrop($event)">
-    <tr>
-      <td class="spiritProjectionLabel" tooltip="You can project your spiritual self to take on a second activity while your physical body continues its work. Whatever activity you drop here will be completed each day as long as you have enough mana to support the effort. Requires 5 mana.">
-        Spiritual Projection
-      </td>
-    </tr>
-    <tr *ngIf="activityService.spiritActivity">
-      <td>{{activityService.getActivityByType(activityService.spiritActivity).name[activityService.getActivityByType(activityService.spiritActivity).level]}}</td>
-      <td>
-        <div class="progress-bar indeterminate">
-          <span></span>
-        </div>
-      </td>
-      <td>
-        <mat-icon tooltip="Remove this activity from the schedule." (click)="removeSpiritActivity()" class="iconButton">clear</mat-icon>
-      </td>
-    </tr>
-  </table>
+      <tr>
+        <td class="spiritProjectionLabel" tooltip="You can project your spiritual self to take on a second activity while your physical body continues its work. Whatever activity you drop here will be completed each day as long as you have enough mana to support the effort. Requires 5 mana.">
+          Spiritual Projection
+        </td>
+      </tr>
+      <tr *ngIf="activityService.spiritActivity">
+        <td>{{activityService.getActivityByType(activityService.spiritActivity).name[activityService.getActivityByType(activityService.spiritActivity).level]}}</td>
+        <td>
+          <div class="progress-bar indeterminate">
+            <span></span>
+          </div>
+        </td>
+        <td>
+          <mat-icon tooltip="Remove this activity from the schedule." (click)="removeSpiritActivity()" class="iconButton">clear</mat-icon>
+        </td>
+      </tr>
+    </table>
+  </div>
+
   <div>
     <span>
       <mat-icon tooltip="Save your current schedule of actviities." class="iconButton" (click)="activityService.saveActivityLoop()">
         content_paste
       </mat-icon>
-      <mat-icon tooltip="Load your saved schedule of actviities. Note that activities that you cannot do right now will not be loaded." 
+      <mat-icon tooltip="Load your saved schedule of actviities. Note that activities that you cannot do right now will not be loaded."
         class="iconButton" (click)="activityService.loadActivityLoop()">
         content_paste_go
       </mat-icon>
-      <mat-icon tooltip="Clear your current schedule." 
+      <mat-icon tooltip="Clear your current schedule."
         class="iconButton" (click)="activityService.activityLoop = []">
         delete_sweep
       </mat-icon>

--- a/src/app/time-panel/time-panel.component.less
+++ b/src/app/time-panel/time-panel.component.less
@@ -3,6 +3,8 @@
 .dropAccepter {
   width: 100%;
   height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 table {
@@ -69,4 +71,8 @@ h6 {
 
 input {
   vertical-align: middle;
+}
+
+.overflow {
+  overflow: auto;
 }


### PR DESCRIPTION
Ensures that the header and footer on the schedule tab are always visible.

Additionally, fixes the height of both the schedule and attribute panel to both be half the height of the remaining space.

![chrome_Q9fO744ruM](https://user-images.githubusercontent.com/5848891/179386589-50d0be89-6594-4e38-a241-03f8e5e7c5cd.gif)
