### PR TITLE
fix: attribute scaling math above softcap

### DIFF
--- a/src/app/game-state/character.ts
+++ b/src/app/game-state/character.ts
@@ -374,7 +374,7 @@ export class Character {
       // increase by log2 of whatever is over the softcap
       return this.attributeScalingLimit + (this.attributeScalingLimit * 9 / 4) +
         (this.attributeScalingLimit * 90 / 20) +
-        (this.attributeScalingLimit * (this.attributeSoftCap - 100) / 100) +
+        (this.attributeSoftCap - (this.attributeScalingLimit * 100)) / 100 +
         Math.log2(aptitude - this.attributeSoftCap + 1);
     }
   }


### PR DESCRIPTION
[Original bug from Cho Quan](https://discord.com/channels/996414713766363146/996488799938936922/998133259714183229)

Math double checked and I came up with a slightly different implementation that closer matches current implementation.

Concern is that many players are progressing far with spirituality scaling with the wrong aptitude multiplier, so it is treated as a "feature" not a "bug".