### PR TITLE
fix: bloodline rank five and lifespan

### DIFF
--- a/src/app/ascension-store-modal/ascension-store-modal.component.html
+++ b/src/app/ascension-store-modal/ascension-store-modal.component.html
@@ -38,17 +38,17 @@
     </tr>
     <tr>
       <td>
-        <button [disabled]="characterService.characterState.bloodlineRank >= 4" (click)="storeService.upgradeBloodline()">{{storeService.bloodlineLabel}}</button>
+        <button [disabled]="characterService.characterState.bloodlineRank >= 5" (click)="storeService.upgradeBloodline()">{{storeService.bloodlineLabel}}</button>
       </td>
       <td>
         {{storeService.bloodlineDescription}}
         <br>
         Current Rank: {{characterService.characterState.bloodlineRank}}
         <br>
-        <span *ngIf="characterService.characterState.bloodlineRank < 4">
+        <span *ngIf="characterService.characterState.bloodlineRank < 5">
           Next rank requires {{characterService.characterState.bloodlineCost | number}} spirituality and a {{this.storeService.bloodLineHomeRequirement.name}}.
         </span>
-        <span *ngIf="characterService.characterState.bloodlineRank >= 4">
+        <span *ngIf="characterService.characterState.bloodlineRank >= 5">
           Max Rank
         </span>
       </td>

--- a/src/app/game-state/achievement.service.ts
+++ b/src/app/game-state/achievement.service.ts
@@ -549,7 +549,7 @@ export class AchievementService {
       check: () => {
         return (this.characterService.soulCoreRank() >= 4) &&
           (this.characterService.meridianRank() >= 4) &&
-          this.characterService.characterState.bloodlineRank >= 4;
+          this.characterService.characterState.bloodlineRank >= 5;
       },
       effect: () => {
         this.impossibleTaskService.impossibleTasksUnlocked = true;

--- a/src/app/game-state/character.service.ts
+++ b/src/app/game-state/character.service.ts
@@ -227,7 +227,7 @@ export class CharacterService {
   }
 
   upgradeBloodline() {
-    if (this.characterState.bloodlineRank > 4){
+    if (this.characterState.bloodlineRank >= 5){
       // double check we're not going over the max rank
       return;
     }

--- a/src/app/game-state/character.ts
+++ b/src/app/game-state/character.ts
@@ -255,7 +255,7 @@ export class Character {
     totalAptitude += this.attributes.strength.aptitude + this.attributes.toughness.aptitude +
       this.attributes.speed.aptitude + this.attributes.intelligence.aptitude + this.attributes.charisma.aptitude;
     this.statLifespan = this.getAptitudeMultipier(totalAptitude / 5);
-    if (this.bloodlineRank < 4){
+    if (this.bloodlineRank < 5){
       this.statLifespan *= 0.1;
     }
 
@@ -274,18 +274,18 @@ export class Character {
         this.attributes[keys[key]].lifeStartValue = this.attributes[keys[key]].value;
       }
     }
-    if (this.bloodlineRank < 3){
+    if (this.bloodlineRank < 3) {
       this.money = 0;
-    } else if (this.bloodlineRank < 4){
+    } else if (this.bloodlineRank < 4) {
       this.money = this.money / 8;
     } else {
       this.money = 4 * this.money;
     }
-    if (this.money > this.maxMoney){
+    if (this.money > this.maxMoney) {
       this.money = this.maxMoney;
     }
     this.recalculateDerivedStats();
-    if (this.bloodlineRank == 0){
+    if (this.bloodlineRank == 0) {
       this.equipment = {
         head: null,
         body: null,
@@ -294,7 +294,7 @@ export class Character {
         legs: null,
         feet: null
       }
-    } else if (this.bloodlineRank <= 1){
+    } else if (this.bloodlineRank <= 1) {
       this.equipment.body = null;
       this.equipment.head = null;
       this.equipment.legs = null;

--- a/src/app/game-state/store.service.ts
+++ b/src/app/game-state/store.service.ts
@@ -98,26 +98,33 @@ export class StoreService {
   updateAscensions(){
     this.soulCoreRank = this.characterService.soulCoreRank();
     this.meridianRank = this.characterService.meridianRank();
-    if (this.characterService.characterState.bloodlineRank == 0){
+    if (this.characterService.characterState.bloodlineRank === 0){
       this.bloodlineLabel = "Establish Bloodline";
     } else {
       this.bloodlineLabel = "Enhance Bloodline";
     }
-    if (this.characterService.characterState.bloodlineRank == 0){
+    if (this.characterService.characterState.bloodlineRank === 0){
+      // Weapons
       this.bloodlineDescription = "End your current life, sacrifice all attributes and aptitudes, and establish a bloodline. All of your future reincarnations will be born as your own descendants. Your weapons equipped on death will become family heirlooms and will be inherited by your future self.";
       this.bloodLineHomeRequirement = this.homeService.homesList[HomeType.Mansion];
-    } else if (this.characterService.characterState.bloodlineRank == 1){
+    } else if (this.characterService.characterState.bloodlineRank === 1){
+      // Armor
       this.bloodlineDescription = "End your current life, sacrifice all attributes and aptitudes, and enhance your bloodline. Your armor and your weapons equipped on death will become family heirlooms and will be inherited by your future self.";
       this.bloodLineHomeRequirement = this.homeService.homesList[HomeType.Palace];
-    } else if (this.characterService.characterState.bloodlineRank == 2){
+    } else if (this.characterService.characterState.bloodlineRank === 2){
+      // Inherit Money
       this.bloodlineDescription = "End your current life, sacrifice all attributes and aptitudes, and enhance your bloodline. Your armor and your weapons equipped on death will become family heirlooms and will be inherited by your future self. You will also inherit some of your past self's money.";
       this.bloodLineHomeRequirement = this.homeService.homesList[HomeType.Castle];
-    } else if (this.characterService.characterState.bloodlineRank == 3){
+    } else if (this.characterService.characterState.bloodlineRank === 3){
+      // Interest
       this.bloodlineDescription = "End your current life, sacrifice all attributes and aptitudes, and enhance your bloodline. Your armor and your weapons equipped on death will become family heirlooms and will be inherited by your future self. You will also inherit your past self's money plus interest.";
       this.bloodLineHomeRequirement = this.homeService.homesList[HomeType.Fortress];
-    } else if (this.characterService.characterState.bloodlineRank == 4){
+    } else if (this.characterService.characterState.bloodlineRank === 4){
+      // Basic Stat Lifespan
       this.bloodlineDescription = "End your current life, sacrifice all attributes and aptitudes, and enhance your bloodline. Your armor and your weapons equipped on death will become family heirlooms and will be inherited by your future self. You will also inherit your past self's money plus interest. Your aptitudes extend your lifespan to a much greater degree.";
       this.bloodLineHomeRequirement = this.homeService.homesList[HomeType.Mountain];
+    } else if (this.characterService.characterState.bloodlineRank === 5){
+      this.bloodlineDescription = "You can't enhance your bloodline any further. Your armor and your weapons equipped on death will become family heirlooms and will be inherited by your future self. You will also inherit your past self's money plus interest. Your aptitudes extend your lifespan to a much greater degree.";
     }
 
   }
@@ -162,7 +169,7 @@ export class StoreService {
       this.logService.addLogMessage("You don't have the spirituality required to ascend.","INJURY","EVENT");
       return;
     }
-    if (this.characterService.characterState.bloodlineRank >= 4){
+    if (this.characterService.characterState.bloodlineRank >= 5){
       this.logService.addLogMessage("You can't enhance your bloodline any further.","INJURY","EVENT");
       return;
     }


### PR DESCRIPTION
[Original bug by Cho Quan](https://discord.com/channels/996414713766363146/996488799938936922/998227561584808007)

Possible Solutions:
1. Change wording of bloodline rank 4 to also add lifespan
2. **Enable purchasing of Bloodline Rank 5 & change requirement to match wording**
3. other

I've gone with option two, but am very open to being overridden.

I am not a huge fan of making balance changes, but I feel this game is desperately in need of some. This one teeters on a bug fix.

I did not look at Soul Core/Meridians, they may have a similar 'bug'.