### PR TITLE
Add alt and ctrl click, fix tooltip

### DIFF
--- a/src/app/activity-panel/activity-panel.component.html
+++ b/src/app/activity-panel/activity-panel.component.html
@@ -10,8 +10,13 @@
       <tr *ngIf="(activity.unlocked)" draggable="true" (dragstart)="drag(activity, $event)">
         <td>
           <span class="noWrap">
-            <button (click)="onClick(activity, $event)" 
-                    tooltip="Add this activity to your schedule. Shift click to also repeat it for 10 days.">
+            <button (click)="onClick(activity, $event)"
+                    tooltip="Add this to your schedule
+
+                    Shift- or Ctrl-click to repeat it 10x
+                    Shift-Ctrl-click to repeat it 100x
+                    Alt-click to add it to the top"
+                    tooltipClass="tooltip-break">
               {{activity.name[activity.level]}}
             </button>
             <mat-icon *ngIf="activity.skipApprenticeshipLevel > 0"

--- a/src/app/activity-panel/activity-panel.component.ts
+++ b/src/app/activity-panel/activity-panel.component.ts
@@ -23,10 +23,23 @@ export class ActivityPanelComponent {
   }
 
   onClick(activity: Activity, event: MouseEvent): void {
-    this.activityService.activityLoop.push({
-      activity: activity.activityType,
-      repeatTimes: event.shiftKey ? 10 : 1
-    });
+    // Shift and Ctrl both multiply by 10x, combined does 100
+    let repeat = 1
+    repeat *= event.shiftKey ? 10 : 1
+    repeat *= event.ctrlKey ? 10 : 1
+
+    // Alt will put it at the top of the schedule, otherwise the bottom
+    if (event.altKey) {
+      this.activityService.activityLoop.unshift({
+        activity: activity.activityType,
+        repeatTimes: repeat
+      });
+    } else {
+      this.activityService.activityLoop.push({
+        activity: activity.activityType,
+        repeatTimes: repeat
+      });
+    }
   }
 
   drag(activity: Activity, event: DragEvent){

--- a/src/app/attributes-panel/attributes-panel.component.html
+++ b/src/app/attributes-panel/attributes-panel.component.html
@@ -29,7 +29,10 @@
             <span tooltip="{{follower.name}} is a level {{follower.power}} {{follower.job | titlecase}}. {{followerService.jobs[follower.job].description}}<br/>{{follower.name}} has followed you for {{follower.age / 365 | number: '1.0-1'}} years and will serve for another {{(follower.lifespan - follower.age) / 365 | number: '1.0-1'}} more years.">
               {{follower.name | titlecase}} the {{follower.job | titlecase}}
             </span>
-            <mat-icon class="smallerIcon" (click)="dismissFollower($event, follower)" tooltip="Dismiss this follower. If you have the right knowledge, you can shift-click to automatically dismiss all followers with this job.">
+            <mat-icon class="smallerIcon"
+            (click)="dismissFollower($event, follower)"
+            [tooltip]="followerService.autoDismissUnlocked ? 'Dismiss this follower.\n\nShift-click to automatically dismiss this job type': 'Dismiss this follower.'"
+            tooltipClass="tooltip-break">
               cancel
             </mat-icon>
         </div>

--- a/src/styles.less
+++ b/src/styles.less
@@ -170,3 +170,7 @@ button:disabled {
   animation-iteration-count: infinite;
   animation-timing-function: linear;
 }
+
+.tooltip-break {
+  white-space: pre-line;
+}


### PR DESCRIPTION
Adds the ability to Alt click an activity to put it at the top of the schedule, and makes it so both Ctrl and Shift click multiplies the amount added by 10 (combined for 100).

Also updates the follower dismiss tooltip to only show the details about auto-dismissal if you have it unlocked