### PR TITLE
Fix: Improving home information

### DIFF
--- a/src/app/ascension-store-modal/ascension-store-modal.component.html
+++ b/src/app/ascension-store-modal/ascension-store-modal.component.html
@@ -55,6 +55,6 @@
     </tr>
   </table>
   <span *ngIf="characterService.characterState.empowermentFactor > 1">
-    You have consumed {{(characterService.characterState.empowermentFactor - 1) * 100 | number:'1.0-0'}} Empowerment Pills which multiplies all your attribute gains by {{characterService.characterState.empowermentFactor  | number:'1.0-2'}}.
+    You have consumed {{(characterService.characterState.empowermentFactor - 1) * 100 | number:'1.0-0'}} Empowerment Pills which multiplies all your attribute gains by {{characterService.characterState.empowermentFactor  | number:'1.0-2'}}. You will always keep this bonus, even after ascending.
   </span>
 </div>

--- a/src/app/game-state/home.service.ts
+++ b/src/app/game-state/home.service.ts
@@ -15,6 +15,7 @@ export interface Home {
   costPerDay: number;
   landRequired: number;
   maxInventory: number;
+  upgradeToTooltip: string;
   consequence: () => void;
   furnitureSlots: FurniturePosition[];
   daysToBuild: number;
@@ -118,6 +119,7 @@ export class HomeService {
       costPerDay: 0,
       landRequired: 0,
       maxInventory: 10,
+      upgradeToTooltip: "Get a better house.",
       consequence: () => {
         if (Math.random() < 0.05){
           this.logService.addLogMessage("Some troublemakers stole some money while you were sleeping. It might be time to get some walls.", 'INJURY', 'EVENT');
@@ -138,6 +140,7 @@ export class HomeService {
       costPerDay: 1,
       landRequired: 1,
       maxInventory: 12,
+      upgradeToTooltip: "Get a better house. A better home will cost 100 taels and take up 5 land. The new home will restore 1 stamina and a bit of health each night.",
       consequence: () => {
         this.characterService.characterState.status.health.value += .5;
         this.characterService.characterState.status.stamina.value += 1;
@@ -161,6 +164,7 @@ export class HomeService {
       costPerDay: 5,
       landRequired: 5,
       maxInventory: 15,
+      upgradeToTooltip: "Get a better house. A better home will cost 1,000 taels and take up 5 land. The new home will restore 3 stamina and a bit of health each night. It also has walls and space to properly sleep.",
       consequence: () => {
         this.characterService.characterState.status.health.value += .5;
         this.characterService.characterState.status.stamina.value += 3;
@@ -179,6 +183,7 @@ export class HomeService {
       costPerDay: 10,
       landRequired: 10,
       maxInventory: 18,
+      upgradeToTooltip: "Get a better house. A better home will cost 10,000 taels and take up 10 land. The new home will restore 5 stamina and a bit of health each night. It has enough room to properly bathe.",
       consequence: () => {
         this.characterService.characterState.status.health.value += .7;
         this.characterService.characterState.status.stamina.value += 5;
@@ -193,11 +198,12 @@ export class HomeService {
     {
       name: "Pleasant Cottage",
       type: HomeType.PleasantCottage,
-      description: "A nice little home where you can rest peacefully. Automatically restores 10 stamina and a bit of health each night.",
+      description: "A nice little home where you can rest peacefully. Automatically restores 10 stamina, 1 health and a bit of mana each night.",
       cost: 100000,
       costPerDay: 20,
       landRequired: 20,
       maxInventory: 20,
+      upgradeToTooltip: "Get a better house. A better home will cost 100,000 taels and take up 20 land. The new home will restore 10 stamina and 1 health and a bit of mana each night. It also has room to let you cook.",
       consequence: () => {
         this.characterService.characterState.status.mana.value += 0.1;
         this.characterService.characterState.status.health.value += 1;
@@ -214,11 +220,12 @@ export class HomeService {
     {
       name: "Large House",
       type: HomeType.LargeHouse,
-      description: "A large house where you can live and work. Automatically restores 15 stamina and a bit of health each night.",
+      description: "A large house where you can live and work. Automatically restores 15 stamina, 2 health and a bit of mana each night.",
       cost: 1000000,
       costPerDay: 50,
       landRequired: 50,
       maxInventory: 24,
+      upgradeToTooltip: "Get a better house. A better home will cost 1M taels and take up 50 land. The new home will restore 15 stamina and 2 health and a bit of mana each night. It has room to practice your craft.",
       consequence: () => {
         this.characterService.characterState.status.mana.value += 0.2;
         this.characterService.characterState.status.health.value += 2;
@@ -236,11 +243,12 @@ export class HomeService {
     {
       name: "Courtyard House",
       type: HomeType.CourtyardHouse,
-      description: "A large house with a wall and an enclosed courtyard. Perfect for building a thriving business. Automatically restores 20 stamina and a bit of health each night.",
+      description: "A large house with a wall and an enclosed courtyard. Perfect for building a thriving business. Automatically restores 20 stamina, 3 health and a bit of mana each night.",
       cost: 10000000,
       costPerDay: 80,
       landRequired: 80,
       maxInventory: 28,
+      upgradeToTooltip: "Get a better house. A better home will cost 10m taels and take up 80 land. The new home will restore 20 stamina, 3 health and a bit of mana each night.",
       consequence: () => {
         this.characterService.characterState.status.mana.value += 0.3;
         this.characterService.characterState.status.health.value += 3;
@@ -258,11 +266,12 @@ export class HomeService {
     {
       name: "Manor",
       type: HomeType.Manor,
-      description: "A large manor house. You are really moving up in the world. Automatically restores 25 stamina and a bit of health each night.",
+      description: "A large manor house. You are really moving up in the world. Automatically restores 25 stamina, 4 health and a bit of mana each night.",
       cost: 100000000,
       costPerDay: 100,
       landRequired: 100,
       maxInventory: 30,
+      upgradeToTooltip: "Get a better house. A better home will cost 100m taels and take up 100 land. The new home will restore 25 stamina, 4 health and a bit of mana each night.",
       consequence: () => {
         this.characterService.characterState.status.mana.value += 0.4;
         this.characterService.characterState.status.health.value += 4;
@@ -280,11 +289,12 @@ export class HomeService {
     {
       name: "Mansion",
       type: HomeType.Mansion,
-      description: "An elaborate mansion. Automatically restores 30 stamina and a bit of health each night.",
+      description: "An elaborate mansion. Automatically restores 30 stamina, 5 health and a bit of mana each night.",
       cost: 1000000000,
       costPerDay: 120,
       landRequired: 120,
       maxInventory: 32,
+      upgradeToTooltip: "Get a better house. A better home will cost 1B taels and take up 120 land. The new home will restore 30 stamina, 5 health and a bit of mana each night.",
       consequence: () => {
         this.characterService.characterState.status.mana.value += 0.5;
         this.characterService.characterState.status.health.value += 5;
@@ -302,11 +312,12 @@ export class HomeService {
     {
       name: "Palace",
       type: HomeType.Palace,
-      description: "A lavish palace. Automatically restores 35 stamina and a bit of health each night.",
+      description: "A lavish palace. Automatically restores 35 stamina, 10 health and 1 mana each night.",
       cost: 10000000000,
       costPerDay: 150,
       landRequired: 150,
       maxInventory: 36,
+      upgradeToTooltip: "Get a better house. A better home will cost 10B taels and take up 150 land. The new home will restore 35 stamina, 10 health and 1 mana each night.",
       consequence: () => {
         this.characterService.characterState.status.mana.value += 1;
         this.characterService.characterState.status.health.value += 10;
@@ -324,11 +335,12 @@ export class HomeService {
     {
       name: "Castle",
       type: HomeType.Castle,
-      description: "An imposing castle. Automatically restores 40 stamina and a bit of health each night.",
+      description: "An imposing castle. Automatically restores 40 stamina, 15 health and 2 mana each night.",
       cost: 10000000000,
       costPerDay: 150,
       landRequired: 150,
       maxInventory: 40,
+      upgradeToTooltip: "Get a better house. A better home will cost 100B taels and take up 150 land. The new home will restore 40 stamina, 15 health and 2 mana each night.",
       consequence: () => {
         this.characterService.characterState.status.mana.value += 2;
         this.characterService.characterState.status.health.value += 15;
@@ -346,11 +358,12 @@ export class HomeService {
     {
       name: "Fortress",
       type: HomeType.Fortress,
-      description: "An indomitable fortress. Automatically restores 50 stamina and a bit of health each night.",
+      description: "An indomitable fortress. Automatically restores 50 stamina, 20 health and 3 mana each night.",
       cost: 100000000000,
       costPerDay: 180,
       landRequired: 180,
       maxInventory: 50,
+      upgradeToTooltip: "Get a better house. A better home will cost 1T taels and take up 180 land. The new home will restore 50 stamina, 20 health and 3 mana each night.",
       consequence: () => {
         this.characterService.characterState.status.mana.value += 3;
         this.characterService.characterState.status.health.value += 20;
@@ -368,11 +381,12 @@ export class HomeService {
     {
       name: "Mountain",
       type: HomeType.Mountain,
-      description: "An entire mighty mountain. Automatically restores 100 stamina and a bit of health each night.",
+      description: "An entire mighty mountain. Automatically restores 100 stamina, 30 health and 4 mana each night.",
       cost: 1000000000000,
       costPerDay: 500,
       landRequired: 500,
       maxInventory: 60,
+      upgradeToTooltip: "Get a better house. A better home will cost 10T taels and take up 500 land. The new home will restore 100 stamina, 30 health and 4 mana each night.",
       consequence: () => {
         this.characterService.characterState.status.mana.value += 4;
         this.characterService.characterState.status.health.value += 30;
@@ -390,11 +404,12 @@ export class HomeService {
     {
       name: "Forbidden City",
       type: HomeType.ForbiddenCity,
-      description: "A city of your very own. Automatically restores 200 stamina and a bit of health each night.",
+      description: "A city of your very own. Automatically restores 200 stamin, 50 health and 5 mana each night.",
       cost: 10000000000000,
       costPerDay: 1000,
       landRequired: 1000,
       maxInventory: 80,
+      upgradeToTooltip: "Get a better house. A better home will cost 100T taels and take up 1,000 land. The new home will restore 200 stamina, 50 health and 5 mana each night.",
       consequence: () => {
         this.characterService.characterState.status.mana.value += 5;
         this.characterService.characterState.status.health.value += 50;
@@ -412,11 +427,12 @@ export class HomeService {
     {
       name: "Capital",
       type: HomeType.Capital,
-      description: "The entire empire is yours now. Automatically restores 300 stamina and a bit of health each night.",
+      description: "The entire empire is yours now. Automatically restores 300 stamina, 80 health and 10 mana each night.",
       cost: 100000000000000,
       costPerDay: 10000,
       landRequired: 10000,
       maxInventory: 100,
+      upgradeToTooltip: "Get a better house. A better home will cost 1Q taels and take up 10,000 land. The new home will restore 300 stamina, 80 health and 10 mana each night.",
       consequence: () => {
         this.characterService.characterState.status.mana.value += 10;
         this.characterService.characterState.status.health.value += 80;

--- a/src/app/home-panel/home-panel.component.html
+++ b/src/app/home-panel/home-panel.component.html
@@ -24,7 +24,7 @@
               add
             </mat-icon>
             <mat-icon *ngIf="(homeService.home.name !== homeService.nextHome.name)" placement="bottom" (click)="homeService.upgradeToNextHome()" class="iconButton"
-              tooltip="Get a better house. A better home will cost {{homeService.nextHomeCost | bigNumber}} taels and take up {{homeService.nextHome.landRequired | bigNumber}} land.">
+              tooltip="{{homeService.nextHome.upgreadeDescription}}">
               add_business
             </mat-icon>
             <mat-icon class="iconButton" *ngIf="homeService.home.furnitureSlots.length"

--- a/src/app/home-panel/home-panel.component.html
+++ b/src/app/home-panel/home-panel.component.html
@@ -24,7 +24,7 @@
               add
             </mat-icon>
             <mat-icon *ngIf="(homeService.home.name !== homeService.nextHome.name)" placement="bottom" (click)="homeService.upgradeToNextHome()" class="iconButton"
-              tooltip="{{homeService.nextHome.upgreadeDescription}}">
+              tooltip="{{homeService.nextHome.upgradeToTooltip}}">
               add_business
             </mat-icon>
             <mat-icon class="iconButton" *ngIf="homeService.home.furnitureSlots.length"


### PR DESCRIPTION
Empowerment pill clarification can be split out if this tooltip moving isn't appreciated.

House tooltips needed to be updated, since "a bit of health" is inaccurate when it recovers 80, and it doesn't mention mana recovery at all. While we're at it, might as well have the upgrade tooltip say what the advantage of an upgraded house will be. 

Possible changes to consider: 
- changing from "next house's values" to "difference between this house and next house". 
- moving all of this back to home-panel's html and figuring out how to put if statements in html. 
- creating and using variables in the descriptions to make possible/eventual globalization and localization marginally easier.
  - if variables are created, use them inside of consequence function. 