### PR TITLE
Improve contrast of active time panel button

### DIFF
--- a/src/app/time-panel/time-panel.component.less
+++ b/src/app/time-panel/time-panel.component.less
@@ -42,7 +42,8 @@ label {
 }
 
 .iconActive {
-  background-color: var(--activeButtonColor);
+  color: var(--panelBackground);
+  background: var(--bodyText);
 }
 
 .panelHeader {

--- a/src/styles.less
+++ b/src/styles.less
@@ -4,7 +4,6 @@
   --panelBackground: #e9f7ec; //#fcfcfc;
   --panelBorder: #a4c9aC; //#121212;
   --tableDividerColor: #a4c9aC;
-  --activeButtonColor: #d8deff;
   --itemSlotColor: rgb(252, 252, 239);
   --itemSlotHighlight: #d8deff;
   --storeButtonColor: #fdfffc;
@@ -25,7 +24,6 @@
   --panelBackground: #222222;
   --panelBorder: #5a5a5a;
   --tableDividerColor: #aaaaaa;
-  --activeButtonColor: #004444;
   --itemSlotColor: #373737;
   --itemSlotHighlight: #004444;
   --storeButtonColor: #777777;


### PR DESCRIPTION
Because the contrast between the 'active' background color and regular
background color is so low, telling which button in the time panel is
active is not trivial (especially in the dark mode).

Swapping the foreground and background colors of the active button makes
it easy to tell it apart from the others at a glance, while preserving
the color theme.
