### PR TITLE
feature: Auto pause customization

### DIFF
--- a/src/app/game-state/achievement.service.ts
+++ b/src/app/game-state/achievement.service.ts
@@ -109,6 +109,18 @@ export class AchievementService {
       unlocked: false
     },
     {
+      name: "Won't Live Forever",//TODO update description and requirements
+      description: "PLACEHOLDER DESCRIPTION " + this.itemRepoService.items['autoPauseSettingsManual'].name,
+      hint: "PLACEHOLDER HINT",
+      check: () => {
+        return this.characterService.characterState.totalLives >= 88 && this.mainLoopService.totalTicks > 36500;
+      },
+      effect: () => {
+        this.storeService.unlockManual(this.itemRepoService.items['autoPauseSettingsManual']);
+      },
+      unlocked: false
+    },
+    {
       name: "Clang! Clang! Clang!",
       description: "You reached proficiency in blacksmithing and can now work as a Blacksmith without going through an apprenticeship (you still need the attributes for the Blacksmithing activity).",
       hint: "There are lots of activities an aspiring immortal can do on their way to immortality. Maybe you should try getting good at a few of them.",

--- a/src/app/game-state/activity.service.ts
+++ b/src/app/game-state/activity.service.ts
@@ -14,7 +14,7 @@ import { FollowersService } from './followers.service';
 
 export interface ActivityProperties {
   autoRestart: boolean,
-  pauseOnDeath: boolean,
+  pauseOnDeath: boolean,//TODO move to autoPauserService
   activityLoop: ActivityLoopEntry[],
   unlockedActivities: ActivityType[],
   openApprenticeships: number,
@@ -32,7 +32,7 @@ export class ActivityService {
   savedActivityLoop: ActivityLoopEntry[] = [];
   spiritActivity: ActivityType | null = null;
   autoRestart = false;
-  pauseOnDeath = true;
+  pauseOnDeath = true;//TODO move to autoPauserService
   activities: Activity[] = this.getActivityList();
   openApprenticeships = 1;
   oddJobDays = 0;
@@ -154,7 +154,7 @@ export class ActivityService {
     }
     return {
       autoRestart: this.autoRestart,
-      pauseOnDeath: this.pauseOnDeath,
+      pauseOnDeath: this.pauseOnDeath,//TODO move to autoPauserService
       activityLoop: this.activityLoop,
       unlockedActivities: unlockedActivities,
       openApprenticeships: this.openApprenticeships,
@@ -173,7 +173,7 @@ export class ActivityService {
         activity.unlocked = unlockedActivities.includes(activity.activityType);
     }
     this.autoRestart = properties.autoRestart;
-    this.pauseOnDeath = properties.pauseOnDeath;
+    this.pauseOnDeath = properties.pauseOnDeath;//TODO move to autoPauserService
     this.activityLoop = properties.activityLoop;
     this.spiritActivity = properties.spiritActivity || null;
     this.openApprenticeships = properties.openApprenticeships || 0;
@@ -275,7 +275,7 @@ export class ActivityService {
     }
     if (this.autoRestart){
       this.checkRequirements(true);
-      if (this.pauseOnDeath){
+      if (this.pauseOnDeath){//TODO this check doesn't belong here, move this to autoPauserService's DeathAutoPauser
         this.mainLoopService.pause = true;
       }
     } else {

--- a/src/app/game-state/activity.service.ts
+++ b/src/app/game-state/activity.service.ts
@@ -275,9 +275,6 @@ export class ActivityService {
     }
     if (this.autoRestart){
       this.checkRequirements(true);
-      if (this.pauseOnDeath){//TODO this check doesn't belong here, move this to autoPauserService's DeathAutoPauser
-        this.mainLoopService.pause = true;
-      }
     } else {
       this.activityLoop = [];
     }

--- a/src/app/game-state/autoPauser.service.ts
+++ b/src/app/game-state/autoPauser.service.ts
@@ -1,43 +1,41 @@
 import { Injectable } from '@angular/core';
 import { MainLoopService } from './main-loop.service';
 import { CharacterService } from './character.service';
-import { HomeService } from './home.service';
-import { AutoBuyer, FurnitureAutoBuyer, HomeAutoBuyer, LandAndFieldAutoBuyer } from './autoBuyer';
+import { AutoPauser, AgeAutoPauser, LifespanAutoPauser, TimeAutoPauser, DeathAutoPauser } from './autoPauser';
 
-export interface AutoBuyerProperties {
-  autoBuyerSettingsUnlocked: boolean,
-  autoBuyerSettings: AutoBuyerSetting[]
+export interface AutoPauserProperties {
+  autoPauserSettingsUnlocked: boolean,
+  autoPauserSettings: AutoPauserSetting[]
 }
 
-export type AutoBuyerType = 'home' | 'land' | 'furniture';
-export type AutoBuyerSetting = {
+export type AutoPauserType = 'age' | 'lifespan' | 'time' | 'death';// | 'newActivity' | 'items' | 'health' | 'stamina';
+export type AutoPauserSetting = {
   label: string,
-  type: AutoBuyerType,
-  enabled: boolean,
-  waitForFinish: boolean
+  type: AutoPauserType,
+  enabled: boolean
 }
-type AutoBuyersMap = {[key in AutoBuyerType]: AutoBuyer}
+type AutoPausersMap = {[key in AutoPauserType]: AutoPauser}
 
 @Injectable({
   providedIn: 'root'
 })
-export class AutoBuyerService {
-  autoBuyerSettingsUnlocked = false;
+export class AutoPauserService {
+  autoPauserSettingsUnlocked = false;
   
-  autoBuyerSettings: AutoBuyerSetting[] = this.getDefaultSettings();
+  autoPauserSettings: AutoPauserSetting[] = this.getDefaultSettings();
 
-  autobuyers: AutoBuyersMap = {
-    'home': new HomeAutoBuyer(this, this.homeService, this.characterService),
-    'land': new LandAndFieldAutoBuyer(this, this.homeService, this.characterService),
-    'furniture': new FurnitureAutoBuyer(this, this.homeService, this.characterService)
+  autopausers: AutoPausersMap = {
+    'age': new AgeAutoPauser(this, this.characterService),
+    'lifespan': new LifespanAutoPauser(this, this.characterService),
+    'time': new TimeAutoPauser(this, this.characterService),
+    'death': new DeathAutoPauser(this, this.characterService)
   }
 
   constructor(
     private characterService: CharacterService,
-    private homeService: HomeService,
-    mainLoopService: MainLoopService,
+    mainLoopService: MainLoopService,//TODO update with orioer signature when completed
   ) {
-    mainLoopService.tickSubject.subscribe(() => {
+    mainLoopService.tickSubject.subscribe(() => {//TODO do we need to tick the pausers, or do things that trigger the pauser tick?
       if (this.characterService.characterState.dead) {
         return;
       }
@@ -45,41 +43,30 @@ export class AutoBuyerService {
     });
   }
 
-  getProperties(): AutoBuyerProperties {
+  getProperties(): AutoPauserProperties {
     return {
-      autoBuyerSettingsUnlocked: this.autoBuyerSettingsUnlocked,
-      autoBuyerSettings: this.autoBuyerSettings
+      autoPauserSettingsUnlocked: this.autoPauserSettingsUnlocked,
+      autoPauserSettings: this.autoPauserSettings
     };
   }
 
-  setProperties(properties: AutoBuyerProperties) {
+  setProperties(properties: AutoPauserProperties) {
     if (properties) {
-      this.autoBuyerSettingsUnlocked = properties.autoBuyerSettingsUnlocked || false;
-      this.autoBuyerSettings = properties.autoBuyerSettings || this.getDefaultSettings();
+      this.autoPauserSettingsUnlocked = properties.autoPauserSettingsUnlocked || false;
+      this.autoPauserSettings = properties.autoPauserSettings || this.getDefaultSettings();
     } else {
-      this.autoBuyerSettingsUnlocked = false;
-      this.autoBuyerSettings = this.getDefaultSettings();
+      this.autoPauserSettingsUnlocked = false;
+      this.autoPauserSettings = this.getDefaultSettings();
     }
   }
 
-  getDefaultSettings(): AutoBuyerSetting[] {
+  getDefaultSettings(): AutoPauserSetting[] {
     return [{ 
-      label: 'Home',
-      type: 'home',
+      label: 'Death',
+      type: 'death',
       enabled: true,
       waitForFinish: true
-    },
-    {
-      label: 'Furniture',
-      type: 'furniture',
-      enabled: true,
-      waitForFinish: true
-    },
-    { 
-      label: 'Land/Field',
-      type: 'land',
-      enabled: true,
-      waitForFinish: true
+    //, TODO replace this with settings for all autoPausers
     }];
   }
 

--- a/src/app/game-state/autoPauser.service.ts
+++ b/src/app/game-state/autoPauser.service.ts
@@ -1,0 +1,116 @@
+import { Injectable } from '@angular/core';
+import { MainLoopService } from './main-loop.service';
+import { CharacterService } from './character.service';
+import { HomeService } from './home.service';
+import { AutoBuyer, FurnitureAutoBuyer, HomeAutoBuyer, LandAndFieldAutoBuyer } from './autoBuyer';
+
+export interface AutoBuyerProperties {
+  autoBuyerSettingsUnlocked: boolean,
+  autoBuyerSettings: AutoBuyerSetting[]
+}
+
+export type AutoBuyerType = 'home' | 'land' | 'furniture';
+export type AutoBuyerSetting = {
+  label: string,
+  type: AutoBuyerType,
+  enabled: boolean,
+  waitForFinish: boolean
+}
+type AutoBuyersMap = {[key in AutoBuyerType]: AutoBuyer}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AutoBuyerService {
+  autoBuyerSettingsUnlocked = false;
+  
+  autoBuyerSettings: AutoBuyerSetting[] = this.getDefaultSettings();
+
+  autobuyers: AutoBuyersMap = {
+    'home': new HomeAutoBuyer(this, this.homeService, this.characterService),
+    'land': new LandAndFieldAutoBuyer(this, this.homeService, this.characterService),
+    'furniture': new FurnitureAutoBuyer(this, this.homeService, this.characterService)
+  }
+
+  constructor(
+    private characterService: CharacterService,
+    private homeService: HomeService,
+    mainLoopService: MainLoopService,
+  ) {
+    mainLoopService.tickSubject.subscribe(() => {
+      if (this.characterService.characterState.dead) {
+        return;
+      }
+      this.tick();
+    });
+  }
+
+  getProperties(): AutoBuyerProperties {
+    return {
+      autoBuyerSettingsUnlocked: this.autoBuyerSettingsUnlocked,
+      autoBuyerSettings: this.autoBuyerSettings
+    };
+  }
+
+  setProperties(properties: AutoBuyerProperties) {
+    if (properties) {
+      this.autoBuyerSettingsUnlocked = properties.autoBuyerSettingsUnlocked || false;
+      this.autoBuyerSettings = properties.autoBuyerSettings || this.getDefaultSettings();
+    } else {
+      this.autoBuyerSettingsUnlocked = false;
+      this.autoBuyerSettings = this.getDefaultSettings();
+    }
+  }
+
+  getDefaultSettings(): AutoBuyerSetting[] {
+    return [{ 
+      label: 'Home',
+      type: 'home',
+      enabled: true,
+      waitForFinish: true
+    },
+    {
+      label: 'Furniture',
+      type: 'furniture',
+      enabled: true,
+      waitForFinish: true
+    },
+    { 
+      label: 'Land/Field',
+      type: 'land',
+      enabled: true,
+      waitForFinish: true
+    }];
+  }
+
+  tick() {
+    // Use auto-buy reserve amount if enabled in settings, otherwise default to 10 days living expenses (food + lodging)
+    const reserveAmount = this.homeService.useAutoBuyReserve ? this.homeService.autoBuyReserveAmount : (this.homeService.home.costPerDay + 1) * 10;
+
+    // go through priorities in order
+    for (const setting of this.autoBuyerSettings) {
+      const autobuyer: AutoBuyer = this.autobuyers[setting.type];
+
+      // Skip to the next one if we're already done, or if we can't make any progress
+      if (!setting.enabled || !autobuyer.shouldRun() || autobuyer.isBlocked() || autobuyer.isComplete()) {
+        continue;
+      }
+
+      // If we're set to wait for each priority, don't continue if we're just waiting for something to complete
+      // (Ex. waiting for house to finish upgrade)
+      if (autobuyer.isWaiting() && setting.waitForFinish) {
+        break;
+      } else if (autobuyer.isWaiting()) {
+        continue;
+      }
+
+      // Autobuy, initiate!
+      autobuyer.run(reserveAmount);
+
+      // If we're set to wait for each priority, don't continue if we're not complete
+      if (!autobuyer.isComplete() && setting.waitForFinish) {
+        break;
+      }
+    }
+  }
+}

--- a/src/app/game-state/autoPauser.service.ts
+++ b/src/app/game-state/autoPauser.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { MainLoopService } from './main-loop.service';
+import { ReincarnationService } from './reincarnation.service';
 import { CharacterService } from './character.service';
 import { AutoPauser, AgeAutoPauser, LifespanAutoPauser, TimeAutoPauser, DeathAutoPauser } from './autoPauser';
 

--- a/src/app/game-state/autoPauser.ts
+++ b/src/app/game-state/autoPauser.ts
@@ -1,0 +1,116 @@
+import { Injectable } from '@angular/core';
+import { MainLoopService } from './main-loop.service';
+import { CharacterService } from './character.service';
+import { HomeService } from './home.service';
+import { AutoBuyer, FurnitureAutoBuyer, HomeAutoBuyer, LandAndFieldAutoBuyer } from './autoBuyer';
+
+export interface AutoBuyerProperties {
+  autoBuyerSettingsUnlocked: boolean,
+  autoBuyerSettings: AutoBuyerSetting[]
+}
+
+export type AutoBuyerType = 'home' | 'land' | 'furniture';
+export type AutoBuyerSetting = {
+  label: string,
+  type: AutoBuyerType,
+  enabled: boolean,
+  waitForFinish: boolean
+}
+type AutoBuyersMap = {[key in AutoBuyerType]: AutoBuyer}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AutoBuyerService {
+  autoBuyerSettingsUnlocked = false;
+  
+  autoBuyerSettings: AutoBuyerSetting[] = this.getDefaultSettings();
+
+  autobuyers: AutoBuyersMap = {
+    'home': new HomeAutoBuyer(this, this.homeService, this.characterService),
+    'land': new LandAndFieldAutoBuyer(this, this.homeService, this.characterService),
+    'furniture': new FurnitureAutoBuyer(this, this.homeService, this.characterService)
+  }
+
+  constructor(
+    private characterService: CharacterService,
+    private homeService: HomeService,
+    mainLoopService: MainLoopService,
+  ) {
+    mainLoopService.tickSubject.subscribe(() => {
+      if (this.characterService.characterState.dead) {
+        return;
+      }
+      this.tick();
+    });
+  }
+
+  getProperties(): AutoBuyerProperties {
+    return {
+      autoBuyerSettingsUnlocked: this.autoBuyerSettingsUnlocked,
+      autoBuyerSettings: this.autoBuyerSettings
+    };
+  }
+
+  setProperties(properties: AutoBuyerProperties) {
+    if (properties) {
+      this.autoBuyerSettingsUnlocked = properties.autoBuyerSettingsUnlocked || false;
+      this.autoBuyerSettings = properties.autoBuyerSettings || this.getDefaultSettings();
+    } else {
+      this.autoBuyerSettingsUnlocked = false;
+      this.autoBuyerSettings = this.getDefaultSettings();
+    }
+  }
+
+  getDefaultSettings(): AutoBuyerSetting[] {
+    return [{ 
+      label: 'Home',
+      type: 'home',
+      enabled: true,
+      waitForFinish: true
+    },
+    {
+      label: 'Furniture',
+      type: 'furniture',
+      enabled: true,
+      waitForFinish: true
+    },
+    { 
+      label: 'Land/Field',
+      type: 'land',
+      enabled: true,
+      waitForFinish: true
+    }];
+  }
+
+  tick() {
+    // Use auto-buy reserve amount if enabled in settings, otherwise default to 10 days living expenses (food + lodging)
+    const reserveAmount = this.homeService.useAutoBuyReserve ? this.homeService.autoBuyReserveAmount : (this.homeService.home.costPerDay + 1) * 10;
+
+    // go through priorities in order
+    for (const setting of this.autoBuyerSettings) {
+      const autobuyer: AutoBuyer = this.autobuyers[setting.type];
+
+      // Skip to the next one if we're already done, or if we can't make any progress
+      if (!setting.enabled || !autobuyer.shouldRun() || autobuyer.isBlocked() || autobuyer.isComplete()) {
+        continue;
+      }
+
+      // If we're set to wait for each priority, don't continue if we're just waiting for something to complete
+      // (Ex. waiting for house to finish upgrade)
+      if (autobuyer.isWaiting() && setting.waitForFinish) {
+        break;
+      } else if (autobuyer.isWaiting()) {
+        continue;
+      }
+
+      // Autobuy, initiate!
+      autobuyer.run(reserveAmount);
+
+      // If we're set to wait for each priority, don't continue if we're not complete
+      if (!autobuyer.isComplete() && setting.waitForFinish) {
+        break;
+      }
+    }
+  }
+}

--- a/src/app/game-state/autoPauser.ts
+++ b/src/app/game-state/autoPauser.ts
@@ -1,4 +1,5 @@
 import { AutoPauserService } from "./autoPauser.service";
+import { ReincarnationService } from './reincarnation.service';
 import { CharacterService } from "./character.service";
 
 export abstract class AutoPauser {//TODO entire abstract class needs to be redesigned
@@ -23,13 +24,18 @@ export abstract class AutoPauser {//TODO entire abstract class needs to be redes
    */
   abstract isPossible(): boolean;
 
-  /**
-   * Returns true only if the thing that prevents this autobuyer from running is time.
-   * For example, when waiting for a house to finish upgrading so you can buy the next,
-   * or a house is upgrading and will give a needed slot to furniture autobuy.
-   */
-  abstract isWaiting(): boolean;
+}
 
+export class DeathAutoPauser extends AutoPauser {
+
+  isEnabled(): boolean {
+    return this.autoPauserService.getProperties;//TODO get the relevent property
+  }
+
+  run() {
+    //TODO either run the check, or remove this method and just have this subscribe to things like  reincarnationService.reincarnateSubject.subscribe(() => { action });
+  }
+  
 }
 
 //TODO replace autobuyer with autopausers (one of each possible type)

--- a/src/app/game-state/autoPauser.ts
+++ b/src/app/game-state/autoPauser.ts
@@ -1,116 +1,224 @@
-import { Injectable } from '@angular/core';
-import { MainLoopService } from './main-loop.service';
-import { CharacterService } from './character.service';
-import { HomeService } from './home.service';
-import { AutoBuyer, FurnitureAutoBuyer, HomeAutoBuyer, LandAndFieldAutoBuyer } from './autoBuyer';
+import { AutoBuyerService } from "./autoBuyer.service";
+import { CharacterService } from "./character.service";
+import { HomeService } from "./home.service";
 
-export interface AutoBuyerProperties {
-  autoBuyerSettingsUnlocked: boolean,
-  autoBuyerSettings: AutoBuyerSetting[]
-}
-
-export type AutoBuyerType = 'home' | 'land' | 'furniture';
-export type AutoBuyerSetting = {
-  label: string,
-  type: AutoBuyerType,
-  enabled: boolean,
-  waitForFinish: boolean
-}
-type AutoBuyersMap = {[key in AutoBuyerType]: AutoBuyer}
-
-@Injectable({
-  providedIn: 'root'
-})
-export class AutoBuyerService {
-  autoBuyerSettingsUnlocked = false;
-  
-  autoBuyerSettings: AutoBuyerSetting[] = this.getDefaultSettings();
-
-  autobuyers: AutoBuyersMap = {
-    'home': new HomeAutoBuyer(this, this.homeService, this.characterService),
-    'land': new LandAndFieldAutoBuyer(this, this.homeService, this.characterService),
-    'furniture': new FurnitureAutoBuyer(this, this.homeService, this.characterService)
-  }
+export abstract class AutoBuyer {
 
   constructor(
-    private characterService: CharacterService,
-    private homeService: HomeService,
-    mainLoopService: MainLoopService,
-  ) {
-    mainLoopService.tickSubject.subscribe(() => {
-      if (this.characterService.characterState.dead) {
-        return;
+    protected autoBuyerService: AutoBuyerService,
+    protected homeService: HomeService,
+    protected characterService: CharacterService) {}
+
+  /**
+   * Checks if permissions are correct to run this autobuyer.
+   */
+  abstract shouldRun(): boolean;
+
+  /**
+   * Performs the buying action for the autobuyer.
+   * @param reserveAmount Passed in savings amount to prevent over-buying
+   */
+  abstract run(reserveAmount: number): void;
+
+  /**
+   * Returns true only if this autobuyer will never progress without another being run or an action being taken.
+   * For example, if a furniture piece we need to buy is in a slot the house doesn't have
+   */
+  abstract isBlocked(): boolean;
+
+  /**
+   * Returns true only if the thing that prevents this autobuyer from running is time.
+   * For example, when waiting for a house to finish upgrading so you can buy the next,
+   * or a house is upgrading and will give a needed slot to furniture autobuy.
+   */
+  abstract isWaiting(): boolean;
+
+  /**
+   * Returns true if this autobuyer's work is complete
+   */
+  abstract isComplete(): boolean;
+}
+
+export class HomeAutoBuyer extends AutoBuyer {
+  shouldRun(): boolean {
+    return this.homeService.autoBuyHomeUnlocked;
+  }
+
+  run(reserveAmount: number) {
+    // Don't buy land while upgrading.
+    if (!this.homeService.upgrading) {
+      //try to buy as much land as needed.
+      const landRequired = Math.min(
+        this.homeService.calculateAffordableLand(this.characterService.characterState.money - reserveAmount),
+        this.homeService.nextHome.landRequired - this.homeService.land
+      )
+      if (landRequired > 0) {
+        this.homeService.buyLand(landRequired);
       }
-      this.tick();
-    });
-  }
+      // ... Unless there's a home after the next home.
+    } else if (this.homeService.homeValue + 1 < this.homeService.autoBuyHomeLimit) {
+      const nnHome = this.homeService.getHomeFromValue(this.homeService.nextHome.type + 1);
+      if (nnHome && nnHome.landRequired > this.homeService.land) {
+        const landRequired = Math.min(
+          this.homeService.calculateAffordableLand(this.characterService.characterState.money - reserveAmount),
+          nnHome.landRequired - this.homeService.land
+        )
+        if (landRequired > 0) {
+          this.homeService.buyLand(landRequired);
+        }
+      }
+    }
 
-  getProperties(): AutoBuyerProperties {
-    return {
-      autoBuyerSettingsUnlocked: this.autoBuyerSettingsUnlocked,
-      autoBuyerSettings: this.autoBuyerSettings
-    };
-  }
-
-  setProperties(properties: AutoBuyerProperties) {
-    if (properties) {
-      this.autoBuyerSettingsUnlocked = properties.autoBuyerSettingsUnlocked || false;
-      this.autoBuyerSettings = properties.autoBuyerSettings || this.getDefaultSettings();
-    } else {
-      this.autoBuyerSettingsUnlocked = false;
-      this.autoBuyerSettings = this.getDefaultSettings();
+    if (!this.homeService.upgrading && this.homeService.land >= this.homeService.nextHome.landRequired) {
+      if (this.characterService.characterState.money >= this.homeService.nextHomeCost + reserveAmount) {
+        this.homeService.upgradeToNextHome();
+      }
     }
   }
 
-  getDefaultSettings(): AutoBuyerSetting[] {
-    return [{ 
-      label: 'Home',
-      type: 'home',
-      enabled: true,
-      waitForFinish: true
-    },
-    {
-      label: 'Furniture',
-      type: 'furniture',
-      enabled: true,
-      waitForFinish: true
-    },
-    { 
-      label: 'Land/Field',
-      type: 'land',
-      enabled: true,
-      waitForFinish: true
-    }];
+  isBlocked(): boolean {
+    return false;
   }
 
-  tick() {
-    // Use auto-buy reserve amount if enabled in settings, otherwise default to 10 days living expenses (food + lodging)
-    const reserveAmount = this.homeService.useAutoBuyReserve ? this.homeService.autoBuyReserveAmount : (this.homeService.home.costPerDay + 1) * 10;
+  isWaiting(): boolean {
+    // This autobuyer is waiting if the house is being upgraded and we already have the required land for the next home
+    return this.homeService.upgrading && this.homeService.land >= this.homeService.nextHome.landRequired;
+  }
 
-    // go through priorities in order
-    for (const setting of this.autoBuyerSettings) {
-      const autobuyer: AutoBuyer = this.autobuyers[setting.type];
+  isComplete(): boolean {
+    // We're complete if we've bought the last home upgrade, even if it isn't finished building
+    return this.homeService.homeValue >= this.homeService.autoBuyHomeLimit
+      || this.homeService.upgrading && (this.homeService.homeValue + 1 >= this.homeService.autoBuyHomeLimit);
+  }
+}
 
-      // Skip to the next one if we're already done, or if we can't make any progress
-      if (!setting.enabled || !autobuyer.shouldRun() || autobuyer.isBlocked() || autobuyer.isComplete()) {
-        continue;
-      }
+export class LandAndFieldAutoBuyer extends AutoBuyer {
+  shouldRun(): boolean {
+    return this.homeService.autoBuyLandUnlocked || this.homeService.autoFieldUnlocked;
+  }
 
-      // If we're set to wait for each priority, don't continue if we're just waiting for something to complete
-      // (Ex. waiting for house to finish upgrade)
-      if (autobuyer.isWaiting() && setting.waitForFinish) {
-        break;
-      } else if (autobuyer.isWaiting()) {
-        continue;
-      }
-
-      // Autobuy, initiate!
-      autobuyer.run(reserveAmount);
-
-      // If we're set to wait for each priority, don't continue if we're not complete
-      if (!autobuyer.isComplete() && setting.waitForFinish) {
-        break;
+  run(reserveAmount: number) {
+    if (this.homeService.autoBuyLandUnlocked 
+      && this.characterService.characterState.money >= this.homeService.landPrice + reserveAmount) {
+      const landRequired = Math.min(
+        this.homeService.calculateAffordableLand(this.characterService.characterState.money - reserveAmount),
+        this.homeService.autoBuyLandLimit - (this.homeService.land + this.homeService.fields.length + this.homeService.extraFields)
+      )
+      if (landRequired > 0) {
+        this.homeService.buyLand(landRequired);
       }
     }
+
+    if (this.homeService.autoFieldUnlocked) {
+      while (this.homeService.land > 0 && this.homeService.fields.length + this.homeService.extraFields < this.homeService.autoFieldLimit) {
+        this.homeService.addField();
+      }
+    }
+  }
+
+  isBlocked(): boolean {
+    // This autobuyer can be blocked if it needs more fields, but we haven't unlocked buying land yet
+    if (this.homeService.autoFieldUnlocked && !this.homeService.autoBuyLandUnlocked) {
+      return this.homeService.land === 0 && this.homeService.fields.length + this.homeService.extraFields < this.homeService.autoFieldLimit
+    }
+
+    return false;
+  }
+
+  isWaiting(): boolean {
+    return false;
+  }
+
+  isComplete(): boolean {
+    let landComplete = true;
+    if (this.homeService.autoBuyLandUnlocked) {
+      landComplete = this.homeService.land + this.homeService.fields.length + this.homeService.extraFields >= this.homeService.autoBuyLandLimit;
+    }
+
+    let fieldsComplete = true;
+    if (this.homeService.autoFieldUnlocked) {
+      fieldsComplete = this.homeService.fields.length + this.homeService.extraFields >= this.homeService.autoFieldLimit;
+    }
+
+    return landComplete && fieldsComplete;
+  }
+
+}
+
+export class FurnitureAutoBuyer extends AutoBuyer {
+  shouldRun(): boolean {
+    return this.homeService.autoBuyFurnitureUnlocked;
+  }
+
+  run(reserveAmount: number) {
+    for (const slot of this.homeService.furniturePositionsArray) {
+      // check if we have a previous purchase and the slot is still empty
+      if (this.homeService.home.furnitureSlots.includes(slot) && this.homeService.furniture[slot] === null) {
+        const thingToBuy = this.homeService.autoBuyFurniture[slot];
+        if (thingToBuy && this.homeService.furniture[slot]?.id !== thingToBuy.id) {
+          // check if we have the money for the furniture plus the next couple weeks' rent and food by popular demand.
+          if (this.characterService.characterState.money > thingToBuy.value + reserveAmount) {
+            this.homeService.buyFurniture(thingToBuy.id);
+          }
+        }
+      }
+    }
+
+    return true;
+  }
+
+  isBlocked(): boolean {
+    let allNeededSlotsOpen = true;
+    let allAvailableSlotsComplete = true;
+
+    for (const slot of this.homeService.furniturePositionsArray) {
+      const targetItem = this.homeService.autoBuyFurniture[slot];
+      if (targetItem) {
+        if (this.homeService.home.furnitureSlots.includes(slot)) {
+          if (this.homeService.furniture[slot]?.id !== targetItem.id) {
+            allAvailableSlotsComplete = false;
+          }
+        } else {
+          allNeededSlotsOpen = false;
+        }
+      }
+    }
+
+    // This autobuyer is blocked if we've bought everything in the open slots, but a needed slot isn't open
+    // ...and we're not just waiting for a home upgrade that's in progress
+    return !this.homeService.upgrading && allAvailableSlotsComplete && !allNeededSlotsOpen;
+  }
+
+  isWaiting(): boolean {
+    let neededSlotsIncludedInNextHome = false;
+    for (const slot of this.homeService.furniturePositionsArray) {
+      const targetItem = this.homeService.autoBuyFurniture[slot];
+      if (targetItem) {
+        // If the current home doesn't include a slot that the next one does...
+        if (!this.homeService.home.furnitureSlots.includes(slot)
+          && this.homeService.nextHome.furnitureSlots.includes(slot)) {
+            neededSlotsIncludedInNextHome = false;
+        } 
+      }
+    }
+
+    // If the next home we're currently upgrading to has a new, needed slot
+    return this.homeService.upgrading && neededSlotsIncludedInNextHome;
+  }
+
+  isComplete(): boolean {
+    for (const slot of this.homeService.furniturePositionsArray) {
+      const targetItem = this.homeService.autoBuyFurniture[slot];
+      // Automatically consider unfilled auto-buy slots complete
+      if (targetItem) {
+        // If we don't have the slot, or we don't have the last bought furniture, consider incomplete
+        if (!this.homeService.home.furnitureSlots.includes(slot)
+          || this.homeService.furniture[slot]?.id !== targetItem.id) {
+          return false;
+        }
+      }
+    }
+
+    return true;
   }
 }

--- a/src/app/game-state/autoPauser.ts
+++ b/src/app/game-state/autoPauser.ts
@@ -1,30 +1,27 @@
-import { AutoBuyerService } from "./autoBuyer.service";
+import { AutoPauserService } from "./autoPauser.service";
 import { CharacterService } from "./character.service";
-import { HomeService } from "./home.service";
 
-export abstract class AutoBuyer {
+export abstract class AutoPauser {//TODO entire abstract class needs to be redesigned
 
   constructor(
-    protected autoBuyerService: AutoBuyerService,
-    protected homeService: HomeService,
+    protected autoPauserService: AutoPauserService,
     protected characterService: CharacterService) {}
 
   /**
-   * Checks if permissions are correct to run this autobuyer.
+   * Checks if permissions are correct to run this autoPauser
    */
-  abstract shouldRun(): boolean;
+  abstract isEnabled(): boolean;
 
   /**
-   * Performs the buying action for the autobuyer.
+   * Performs the check
    * @param reserveAmount Passed in savings amount to prevent over-buying
    */
   abstract run(reserveAmount: number): void;
 
   /**
-   * Returns true only if this autobuyer will never progress without another being run or an action being taken.
-   * For example, if a furniture piece we need to buy is in a slot the house doesn't have
+   * Checks if this autoPauser's condition is remotely reachable, for example, an immortal won't trigger a death nor lifespan autoPauser
    */
-  abstract isBlocked(): boolean;
+  abstract isPossible(): boolean;
 
   /**
    * Returns true only if the thing that prevents this autobuyer from running is time.
@@ -33,12 +30,9 @@ export abstract class AutoBuyer {
    */
   abstract isWaiting(): boolean;
 
-  /**
-   * Returns true if this autobuyer's work is complete
-   */
-  abstract isComplete(): boolean;
 }
 
+//TODO replace autobuyer with autopausers (one of each possible type)
 export class HomeAutoBuyer extends AutoBuyer {
   shouldRun(): boolean {
     return this.homeService.autoBuyHomeUnlocked;
@@ -89,136 +83,5 @@ export class HomeAutoBuyer extends AutoBuyer {
     // We're complete if we've bought the last home upgrade, even if it isn't finished building
     return this.homeService.homeValue >= this.homeService.autoBuyHomeLimit
       || this.homeService.upgrading && (this.homeService.homeValue + 1 >= this.homeService.autoBuyHomeLimit);
-  }
-}
-
-export class LandAndFieldAutoBuyer extends AutoBuyer {
-  shouldRun(): boolean {
-    return this.homeService.autoBuyLandUnlocked || this.homeService.autoFieldUnlocked;
-  }
-
-  run(reserveAmount: number) {
-    if (this.homeService.autoBuyLandUnlocked 
-      && this.characterService.characterState.money >= this.homeService.landPrice + reserveAmount) {
-      const landRequired = Math.min(
-        this.homeService.calculateAffordableLand(this.characterService.characterState.money - reserveAmount),
-        this.homeService.autoBuyLandLimit - (this.homeService.land + this.homeService.fields.length + this.homeService.extraFields)
-      )
-      if (landRequired > 0) {
-        this.homeService.buyLand(landRequired);
-      }
-    }
-
-    if (this.homeService.autoFieldUnlocked) {
-      while (this.homeService.land > 0 && this.homeService.fields.length + this.homeService.extraFields < this.homeService.autoFieldLimit) {
-        this.homeService.addField();
-      }
-    }
-  }
-
-  isBlocked(): boolean {
-    // This autobuyer can be blocked if it needs more fields, but we haven't unlocked buying land yet
-    if (this.homeService.autoFieldUnlocked && !this.homeService.autoBuyLandUnlocked) {
-      return this.homeService.land === 0 && this.homeService.fields.length + this.homeService.extraFields < this.homeService.autoFieldLimit
-    }
-
-    return false;
-  }
-
-  isWaiting(): boolean {
-    return false;
-  }
-
-  isComplete(): boolean {
-    let landComplete = true;
-    if (this.homeService.autoBuyLandUnlocked) {
-      landComplete = this.homeService.land + this.homeService.fields.length + this.homeService.extraFields >= this.homeService.autoBuyLandLimit;
-    }
-
-    let fieldsComplete = true;
-    if (this.homeService.autoFieldUnlocked) {
-      fieldsComplete = this.homeService.fields.length + this.homeService.extraFields >= this.homeService.autoFieldLimit;
-    }
-
-    return landComplete && fieldsComplete;
-  }
-
-}
-
-export class FurnitureAutoBuyer extends AutoBuyer {
-  shouldRun(): boolean {
-    return this.homeService.autoBuyFurnitureUnlocked;
-  }
-
-  run(reserveAmount: number) {
-    for (const slot of this.homeService.furniturePositionsArray) {
-      // check if we have a previous purchase and the slot is still empty
-      if (this.homeService.home.furnitureSlots.includes(slot) && this.homeService.furniture[slot] === null) {
-        const thingToBuy = this.homeService.autoBuyFurniture[slot];
-        if (thingToBuy && this.homeService.furniture[slot]?.id !== thingToBuy.id) {
-          // check if we have the money for the furniture plus the next couple weeks' rent and food by popular demand.
-          if (this.characterService.characterState.money > thingToBuy.value + reserveAmount) {
-            this.homeService.buyFurniture(thingToBuy.id);
-          }
-        }
-      }
-    }
-
-    return true;
-  }
-
-  isBlocked(): boolean {
-    let allNeededSlotsOpen = true;
-    let allAvailableSlotsComplete = true;
-
-    for (const slot of this.homeService.furniturePositionsArray) {
-      const targetItem = this.homeService.autoBuyFurniture[slot];
-      if (targetItem) {
-        if (this.homeService.home.furnitureSlots.includes(slot)) {
-          if (this.homeService.furniture[slot]?.id !== targetItem.id) {
-            allAvailableSlotsComplete = false;
-          }
-        } else {
-          allNeededSlotsOpen = false;
-        }
-      }
-    }
-
-    // This autobuyer is blocked if we've bought everything in the open slots, but a needed slot isn't open
-    // ...and we're not just waiting for a home upgrade that's in progress
-    return !this.homeService.upgrading && allAvailableSlotsComplete && !allNeededSlotsOpen;
-  }
-
-  isWaiting(): boolean {
-    let neededSlotsIncludedInNextHome = false;
-    for (const slot of this.homeService.furniturePositionsArray) {
-      const targetItem = this.homeService.autoBuyFurniture[slot];
-      if (targetItem) {
-        // If the current home doesn't include a slot that the next one does...
-        if (!this.homeService.home.furnitureSlots.includes(slot)
-          && this.homeService.nextHome.furnitureSlots.includes(slot)) {
-            neededSlotsIncludedInNextHome = false;
-        } 
-      }
-    }
-
-    // If the next home we're currently upgrading to has a new, needed slot
-    return this.homeService.upgrading && neededSlotsIncludedInNextHome;
-  }
-
-  isComplete(): boolean {
-    for (const slot of this.homeService.furniturePositionsArray) {
-      const targetItem = this.homeService.autoBuyFurniture[slot];
-      // Automatically consider unfilled auto-buy slots complete
-      if (targetItem) {
-        // If we don't have the slot, or we don't have the last bought furniture, consider incomplete
-        if (!this.homeService.home.furnitureSlots.includes(slot)
-          || this.homeService.furniture[slot]?.id !== targetItem.id) {
-          return false;
-        }
-      }
-    }
-
-    return true;
   }
 }

--- a/src/app/game-state/game-state.service.ts
+++ b/src/app/game-state/game-state.service.ts
@@ -142,7 +142,7 @@ export class GameStateService {
 
   rebirth(): void {
     this.characterService.forceRebirth = true;
-    this.mainLoopService.pause = false;//TODO possibly check in autpauser service instead
+    this.mainLoopService.pause = false;
   }
 
   cheat(): void {

--- a/src/app/game-state/game-state.service.ts
+++ b/src/app/game-state/game-state.service.ts
@@ -13,6 +13,7 @@ import { InventoryService, InventoryProperties } from './inventory.service';
 import { ItemRepoService } from './item-repo.service';
 import { ImpossibleTaskProperties, ImpossibleTaskService } from './impossibleTask.service';
 import { AutoBuyerProperties, AutoBuyerService } from './autoBuyer.service';
+import { AutoPauserProperties, AutoPauserService } from './autoPauser.service';
 
 const LOCAL_STORAGE_GAME_STATE_KEY = 'immortalityIdleGameState';
 
@@ -26,6 +27,7 @@ interface GameState {
   followers: FollowersProperties,
   logs: LogProperties,
   autoBuy: AutoBuyerProperties,
+  autoPause: AutoPauserProperties,
   mainLoop: MainLoopProperties,
   impossibleTasks: ImpossibleTaskProperties,
   darkMode: boolean
@@ -50,6 +52,7 @@ export class GameStateService {
     private battleService: BattleService,
     private followersService: FollowersService,
     private autoBuyerService: AutoBuyerService,
+    private autoPauseerService: AutoPauserService,
     private mainLoopService: MainLoopService,
     private achievementService: AchievementService,
     private impossibleTaskService: ImpossibleTaskService
@@ -103,6 +106,7 @@ export class GameStateService {
     this.followersService.setProperties(gameState.followers);
     this.logService.setProperties(gameState.logs);
     this.autoBuyerService.setProperties(gameState.autoBuy);
+    this.autoPauserService.setProperties(gameState.autoPause);
     this.mainLoopService.setProperties(gameState.mainLoop);
     this.isDarkMode = gameState.darkMode || false;
 
@@ -120,6 +124,7 @@ export class GameStateService {
       followers: this.followersService.getProperties(),
       logs: this.logService.getProperties(),
       autoBuy: this.autoBuyerService.getProperties(),
+      autoPause: this.autoPauserService.getProperties(),
       mainLoop: this.mainLoopService.getProperties(),
       darkMode: this.isDarkMode,
     };
@@ -137,7 +142,7 @@ export class GameStateService {
 
   rebirth(): void {
     this.characterService.forceRebirth = true;
-    this.mainLoopService.pause = false;
+    this.mainLoopService.pause = false;//TODO possibly check in autpauser service instead
   }
 
   cheat(): void {

--- a/src/app/game-state/item-repo.service.ts
+++ b/src/app/game-state/item-repo.service.ts
@@ -9,6 +9,7 @@ import { Furniture, InventoryService, Item } from './inventory.service';
 import { ImpossibleTaskService, ImpossibleTaskType } from './impossibleTask.service';
 import { FollowersService } from './followers.service';
 import { AutoBuyerService } from './autoBuyer.service';
+import { AutoPauserService } from './autoPauser.service';
 
 @Injectable({
   providedIn: 'root'
@@ -21,6 +22,7 @@ export class ItemRepoService {
   impossibleTaskService?: ImpossibleTaskService;
   followerService?: FollowersService;
   autoBuyerService?: AutoBuyerService;
+  autoPauserService?: AutoPauserService;
 
   furniture: {[key: string]: Furniture} = {
     blanket: {
@@ -1234,6 +1236,29 @@ export class ItemRepoService {
           this.autoBuyerService = this.injector.get(AutoBuyerService);
         }
         return this.autoBuyerService.autoBuyerSettingsUnlocked;
+      }
+    },
+    autoPauserSettingsManual: {//TODO settle on name, cost, description, etc
+      id: 'autoPauseSettingsManual',
+      name: "Manual of Customized Danger Sense",
+      type: "manual",
+      description: "This manual teaches you to customize what triggers an auto-pause.",
+      value: 1000000000,
+      useLabel: "Read",
+      useDescription: "Permanently unlock auto-pausing customization",
+      useConsumes: true,
+      use: () => {
+        if (!this.autoPauserService){
+          this.autoPauserService = this.injector.get(AutoPauserService);
+        }
+        this.autoPauserService.autoPauserSettingsUnlocked = true;
+        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+      },
+      owned: () => {
+        if (!this.autoPauserService){
+          this.autoPauserService = this.injector.get(AutoPauserService);
+        }
+        return this.autoPauserService.autoPauserSettingsUnlocked;
       }
     },
     autoFieldManual: {

--- a/src/app/options-modal/options-modal.component.html
+++ b/src/app/options-modal/options-modal.component.html
@@ -11,6 +11,12 @@
       Automatically plow up to <input value="{{homeService.autoFieldLimit}}" type="number" class="inputBox" (change)="autoFieldLimitChanged($event)"/> fields
     </span>
   </div>
+  <dvi *ngIf="autoPauserService.autoPauseSettingsUnlocked" class="optionField">
+    <span>
+      Auto-Pauser Options:
+      TODO add options to options modal
+    </span>
+  </dvi>
   <div *ngIf="homeService.autoBuyHomeUnlocked" class="optionField">
     <span>
       Automatically upgrade your home up to a

--- a/src/app/options-modal/options-modal.component.ts
+++ b/src/app/options-modal/options-modal.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { AutoBuyerService, AutoBuyerSetting } from '../game-state/autoBuyer.service';
+import { AutoPauserService } from '../game-state/autoPauser.service';
 import { FollowersService } from '../game-state/followers.service';
 import { GameStateService } from '../game-state/game-state.service';
 import { HomeService } from '../game-state/home.service';
@@ -17,7 +18,8 @@ export class OptionsModalComponent {
     public inventoryService: InventoryService,
     public gameStateService: GameStateService,
     public followerService: FollowersService,
-    public autoBuyerService: AutoBuyerService
+    public autoBuyerService: AutoBuyerService,
+    public autoPauserService: AutoPauserService
   ) { }
 
   autoSellReserveChange(event: Event, autosellEntry: AutoItemEntry){
@@ -92,4 +94,10 @@ export class OptionsModalComponent {
     if (!(event.target instanceof HTMLInputElement)) return;
     setting.waitForFinish = event.target.checked;
   }
+
+  autoPauseEnableChange(event: Event): void {
+    if (!(event.target instanceof HTMLInputElement)) return;
+    //TODO make this do the thing
+  }
+  //TODO add listeners for other pauser values changing
 }

--- a/src/app/time-panel/time-panel.component.ts
+++ b/src/app/time-panel/time-panel.component.ts
@@ -100,6 +100,8 @@ export class TimePanelComponent implements OnInit {
   pauseOnDeath(event: Event){
     if (!(event.target instanceof HTMLInputElement)) return;
     this.activityService.pauseOnDeath = event.target.checked;
+    //TODO: move pauseOnDeath from activityService to autoPauseService 
+    //TODO: Consider if we want to leave the option in the time modal, or move or duplicate it in the options modal
   }
 
   useSavedTicks(event: Event){

--- a/src/app/time-panel/time-panel.component.ts
+++ b/src/app/time-panel/time-panel.component.ts
@@ -4,6 +4,7 @@ import { AchievementService } from '../game-state/achievement.service';
 import { ActivityLoopEntry, ActivityType } from '../game-state/activity';
 import { Character } from '../game-state/character';
 import { CharacterService } from '../game-state/character.service';
+import { AutoPauserService } from '../game-state/autoPauser.service';
 import { LogService } from '../game-state/log.service';
 import { MainLoopService } from '../game-state/main-loop.service';
 
@@ -23,6 +24,7 @@ export class TimePanelComponent implements OnInit {
     public mainLoopService: MainLoopService,
     public activityService: ActivityService,
     public characterService: CharacterService,
+    public autoPauserService: AutoPauserService,
   ) {
   }
 
@@ -99,8 +101,8 @@ export class TimePanelComponent implements OnInit {
 
   pauseOnDeath(event: Event){
     if (!(event.target instanceof HTMLInputElement)) return;
-    this.activityService.pauseOnDeath = event.target.checked;
-    //TODO: move pauseOnDeath from activityService to autoPauseService 
+    //this.activityService.pauseOnDeath = event.target.checked;
+    this.autoPauserService.autoPauserSettings.find('death').enabled = event.target.checked;
     //TODO: Consider if we want to leave the option in the time modal, or move or duplicate it in the options modal
   }
 


### PR DESCRIPTION
So, this is mostly being created so that people can look over what I have and discuss it. If I didn't mess anything up (which would need testing to confirm) this shouldn't have any effect besides defaulting pauseOnDeath to true add an achievement and manual that do nothing. 

This is basically an overengineered "pause before death" that only cares about deaths of natural causes. Hoping this is engineered enough to allow adding of any other reasons people might want to pause. Say, having 0 money, or very low health, or getting knocked out. Might need to add internal cooldowns for those, like how TimeAutoPauser works.

Need to add the actual options to the options modal before people can tick anything but pauseOnDeath on, but I'm looking for ideas on things like achievement condition, name, manual cost, hint, etc. All the cool ideas I have would need to add a tracker (times paused, etc). And anyone who sees a problem with how this is currently set up, let me know.