### PR TITLE
Aptitude multiplier balancing

### DIFF
--- a/src/app/game-state/achievement.service.ts
+++ b/src/app/game-state/achievement.service.ts
@@ -431,6 +431,24 @@ export class AchievementService {
       unlocked: false
     },
     {
+      name: "Unlimited Taels",
+      description: "You have unlocked bloodline 4 and now you have unlimited money to spent",
+      hint: "Rumour said that some people are too rich.",
+      check: () => {
+        return this.characterState.bloodlineRank >= 4;
+      },
+      effect: () => {
+        if (this.characterState.bloodlineRank == 4) {
+          this.characterState.bloodlineCost = 10000000000000
+        }
+        
+        if (this.characterState.bloodlineRank == 5) {
+          this.characterState.bloodlineCost = 1000000000000000
+        }
+      },
+      unlocked: false
+    },
+    {
       name: "Grandpa's Old Tent",
       description: "You've gone through eight cycles of reincarnation and come to understand the value of grandfathers.",
       hint: "Just keep playing. I'm sure this will come to an aspiring immortal eventually.",

--- a/src/app/game-state/activity.service.ts
+++ b/src/app/game-state/activity.service.ts
@@ -2054,7 +2054,7 @@ export class ActivityService {
         }
       }],
       requirements: [{
-        charisma: 10000000000,
+        charisma: 500000000,
       }],
       unlocked: false,
       skipApprenticeshipLevel: 0

--- a/src/app/game-state/character.service.ts
+++ b/src/app/game-state/character.service.ts
@@ -232,7 +232,12 @@ export class CharacterService {
     this.logService.addLogMessage(
       "You will be reborn into your own family line and reap greater benefits from your previous lives.",
       'STANDARD', 'STORY');
-    this.characterState.bloodlineCost *= 1000;
+    // Bloodline 1 Cost: base cost
+    // Bloodline 2 Cost: 1,000 x base cost
+    // Bloodline 3 Cost: 750,000 x base cost
+    // Bloodline 4 Cost: 375,000,000 x base cost
+    // Bloodline 5 Cost: 93,750,000,000 x base cost
+    this.characterState.bloodlineCost *= 1000 - 250 * this.characterState.bloodlineRank;
     this.characterState.bloodlineRank++;
     this.resetAptitudes();
   }

--- a/src/app/game-state/character.service.ts
+++ b/src/app/game-state/character.service.ts
@@ -232,13 +232,11 @@ export class CharacterService {
     this.logService.addLogMessage(
       "You will be reborn into your own family line and reap greater benefits from your previous lives.",
       'STANDARD', 'STORY');
-    // Bloodline 1 Cost: base cost
-    // Bloodline 2 Cost: 1,000 x base cost
-    // Bloodline 3 Cost: 750,000 x base cost
-    // Bloodline 4 Cost: 375,000,000 x base cost
-    // Bloodline 5 Cost: 93,750,000,000 x base cost
-    this.characterState.bloodlineCost *= 1000 - 250 * this.characterState.bloodlineRank;
+    this.characterState.bloodlineCost *= 1000;
     this.characterState.bloodlineRank++;
+    if (this.characterState.bloodlineRank >= 4) {
+      this.characterState.bloodlineCost /= 10;
+    }
     this.resetAptitudes();
   }
 

--- a/src/app/game-state/character.ts
+++ b/src/app/game-state/character.ts
@@ -377,18 +377,19 @@ export class Character {
       // from the 10x limit to 100x the limit, change growth rate to 1/20
       return (this.attributeScalingLimit + (this.attributeScalingLimit * 9 / 4) +
         ((aptitude - (this.attributeScalingLimit * 10)) / 20))  * empowermentFactor;
-    } else if (aptitude < this.attributeSoftCap){
+    } else if (aptitude <= this.attributeSoftCap){
       // from the 100x limit to softcap, change growth rate to 1/100
       return (this.attributeScalingLimit + (this.attributeScalingLimit * 9 / 4) +
         (this.attributeScalingLimit * 90 / 20) +
         ((aptitude - (this.attributeScalingLimit * 100)) / 100)) * empowermentFactor;
     } else {
-      // increase by aptitude / (1 + aptitude ^ pow) of whatever is over the softcap. 
-      const pow = 0.5; // Power can be balanced as needed. Lower power reduces returns.
-      return (this.attributeScalingLimit + (this.attributeScalingLimit * 9 / 4) +
+      // graph of y = x ^ 0.1 * log(x) + c
+      const c = this.attributeScalingLimit + (this.attributeScalingLimit * 9 / 4) +
         (this.attributeScalingLimit * 90 / 20) +
-        (this.attributeSoftCap - (this.attributeScalingLimit * 100)) / 100 +
-        (Math.pow (aptitude - this.attributeSoftCap, pow)) * Math.pow(this.attributeScalingLimit / 500000, 0.3))  * empowermentFactor;
+        (this.attributeSoftCap - (this.attributeScalingLimit * 100)) / 100;
+      const x = (aptitude - this.attributeSoftCap) * this.attributeScalingLimit / 10;
+
+      return (Math.pow(x, 0.1) * Math.log(x) + c) * empowermentFactor;
     }
   }
 


### PR DESCRIPTION
Balance update:
- Aptitude multiplier will grow very slow once more than 100,000, thus fixing the problem of too many lifespan and too many stats

Reducing the cost to train followers to become 500m
and reducing the cost of bloodline 5 to become 9.375T
in order to make sure the game not become too hard after the nerf.