### PR TITLE
MACOS: Use ctrl OR cmd click due to OS reservation

### DIFF
--- a/src/app/activity-panel/activity-panel.component.ts
+++ b/src/app/activity-panel/activity-panel.component.ts
@@ -49,7 +49,7 @@ export class ActivityPanelComponent {
     // Shift and Ctrl both multiply by 10x, combined does 100
     let repeat = 1
     repeat *= event.shiftKey ? 10 : 1
-    repeat *= event.ctrlKey ? 10 : 1
+    repeat *= event.ctrlKey || event.metaKey ? 10 : 1
 
     // Alt will put it at the top of the schedule, otherwise the bottom
     if (event.altKey) {

--- a/src/app/attributes-panel/attributes-panel.component.ts
+++ b/src/app/attributes-panel/attributes-panel.component.ts
@@ -36,7 +36,7 @@ export class AttributesPanelComponent {
   dismissFollower(event: MouseEvent, follower: Follower){
     event.preventDefault();
     event.stopPropagation();
-    if (event.ctrlKey && this.followerService.autoDismissUnlocked){
+    if (event.ctrlKey || event.metaKey && this.followerService.autoDismissUnlocked){
       this.followerService.limitFollower(follower);
     } else if (event.shiftKey && this.followerService.autoDismissUnlocked){
       this.followerService.dismissFollowerAll(follower);

--- a/src/app/farm-panel/farm-panel.component.ts
+++ b/src/app/farm-panel/farm-panel.component.ts
@@ -23,7 +23,7 @@ export class FarmPanelComponent {
     event.stopPropagation();
     if (event.shiftKey){
       this.homeService.clearField(10);
-    } else if (event.ctrlKey){
+    } else if (event.ctrlKey || event.metaKey){
       this.homeService.clearField(-1);
     } else {
       this.homeService.clearField();
@@ -36,7 +36,7 @@ export class FarmPanelComponent {
     event.stopPropagation();
     if (event.shiftKey){
       this.homeService.buyLand(10);
-    } else if (event.ctrlKey){
+    } else if (event.ctrlKey || event.metaKey){
       this.homeService.buyLand(-1);
     } else {
       this.homeService.buyLand(1);
@@ -48,7 +48,7 @@ export class FarmPanelComponent {
     event.stopPropagation();
     if (event.shiftKey){
       this.homeService.addField(10);
-    } else if (event.ctrlKey){
+    } else if (event.ctrlKey || event.metaKey){
       this.homeService.addField(-1);
     } else {
       this.homeService.addField();

--- a/src/app/home-panel/home-panel.component.ts
+++ b/src/app/home-panel/home-panel.component.ts
@@ -46,7 +46,7 @@ export class HomePanelComponent {
     event.stopPropagation();
     if (event.shiftKey){
       this.homeService.buyLand(10);
-    } else if (event.ctrlKey){
+    } else if (event.ctrlKey || event.metaKey){
       this.homeService.buyLand(-1);
     } else {
       this.homeService.buyLand(1);
@@ -58,7 +58,7 @@ export class HomePanelComponent {
     event.stopPropagation();
     if (event.shiftKey){
       this.homeService.addField(10);
-    } else if (event.ctrlKey){
+    } else if (event.ctrlKey || event.metaKey){
       this.homeService.addField(-1);
     } else {
       this.homeService.addField();

--- a/src/app/inventory-panel/inventory-panel.component.ts
+++ b/src/app/inventory-panel/inventory-panel.component.ts
@@ -34,7 +34,7 @@ export class InventoryPanelComponent {
       this.inventoryService.selectedItem = item;
       this.use();
       this.inventoryService.selectedItem = oldSelected;
-    } else if (event.ctrlKey) {
+    } else if (event.ctrlKey || event.metaKey) {
       this.inventoryService.selectedItem = item;
       this.autoUse();
     } else {
@@ -60,7 +60,7 @@ export class InventoryPanelComponent {
     event.preventDefault();
     event.stopPropagation();
     this.inventoryService.selectedItem = item;
-    if (event.ctrlKey) {
+    if (event.ctrlKey || event.metaKey) {
       this.autoSell();
     } else if (event.shiftKey) {
       this.sellStack();

--- a/src/app/time-panel/time-panel.component.ts
+++ b/src/app/time-panel/time-panel.component.ts
@@ -72,7 +72,7 @@ export class TimePanelComponent implements OnInit {
     // Shift and Ctrl both multiply by 10x, combined does 100
     let repeat = 1
     repeat *= event.shiftKey ? 10 : 1
-    repeat *= event.ctrlKey ? 10 : 1
+    repeat *= event.ctrlKey || event.metaKey ? 10 : 1
 
     entry.repeatTimes += repeat
   }
@@ -83,7 +83,7 @@ export class TimePanelComponent implements OnInit {
     // Shift and Ctrl both multiply by 10x, combined does 100
     let repeat = 1
     repeat *= event.shiftKey ? 10 : 1
-    repeat *= event.ctrlKey ? 10 : 1
+    repeat *= event.ctrlKey || event.metaKey ? 10 : 1
 
     entry.repeatTimes -= repeat
 


### PR DESCRIPTION
Very simple adjustment here. I use a macbook to play the game, but ctrl-click gets reserved at the OS level to perform a right click action. (Or vice versa depending on perspective)

This PR just adds an OR event.metaKey to the places where event.ctrlKey is used. I didn't make any interface changes, because I didn't know how that might want to be handled up stream, but at least the functionality is accessible now.