### PR TITLE
Fix: FPS drop for high ticks, bankedTicks gain/use

### DIFF
--- a/src/app/game-state/item-repo.service.ts
+++ b/src/app/game-state/item-repo.service.ts
@@ -1010,6 +1010,7 @@ export class ItemRepoService {
       useConsumes: true,
       use: () => {
         this.mainLoopService.unlockFastSpeed = true;
+        this.mainLoopService.topDivider = this.mainLoopService.topDivider > 5 ? 5: this.mainLoopService.topDivider;
         this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
@@ -1031,6 +1032,7 @@ export class ItemRepoService {
       useConsumes: true,
       use: () => {
         this.mainLoopService.unlockFasterSpeed = true;
+        this.mainLoopService.topDivider = this.mainLoopService.topDivider > 2 ? 2: this.mainLoopService.topDivider;
         this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
@@ -1052,6 +1054,7 @@ export class ItemRepoService {
       useConsumes: true,
       use: () => {
         this.mainLoopService.unlockFastestSpeed = true;
+        this.mainLoopService.topDivider = 1;
         this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {

--- a/src/app/game-state/main-loop.service.ts
+++ b/src/app/game-state/main-loop.service.ts
@@ -38,7 +38,7 @@ export class MainLoopService {
   unlockFastSpeed = false;
   unlockFasterSpeed = false;
   unlockFastestSpeed = false;
-  topDivider = 1;
+  topDivider = 10;
   unlockAgeSpeed = false;
   unlockPlaytimeSpeed = false;
   lastTime: number = new Date().getTime();
@@ -118,7 +118,7 @@ export class MainLoopService {
       } else {
         if (this.bankedTicks > 0 && this.useBankedTicks){
           //using banked ticks makes time happen 10 times faster
-          ticksPassed *= 10;
+          ticksPassed *= 11; // Include the normal tick
           this.bankedTicks -= timeDiff / TICK_INTERVAL_MS * 10 * (this.topDivider / this.tickDivider);
         }
 

--- a/src/app/game-state/main-loop.service.ts
+++ b/src/app/game-state/main-loop.service.ts
@@ -123,6 +123,7 @@ export class MainLoopService {
 
         ticksPassed *= this.getTPS(this.tickDivider) / 1000 * TICK_INTERVAL_MS;
         this.tickCount += ticksPassed;
+        const bankedRate = this.tickDivider/this.topDivider;
         if (this.tickCount > 36500) {
           //emergency lag prevention; this should never activate normally
           this.tickCount = 36500;
@@ -133,7 +134,7 @@ export class MainLoopService {
             this.tick();
             if (this.bankedTicks >= 1 && bankedCounter > 1){ // Used here to avoid overusing earned bankedticks.
               bankedCounter--
-              this.bankedTicks -= this.tickDivider/this.topDivider;
+              this.bankedTicks -= bankedRate;
             } else {
               this.tickCount--;
               bankedCounter = 11;

--- a/src/app/game-state/main-loop.service.ts
+++ b/src/app/game-state/main-loop.service.ts
@@ -116,10 +116,10 @@ export class MainLoopService {
       if (this.pause) {
         this.bankedTicks += ticksPassed / this.offlineDivider; // offlineDivider currently either 10 or 2.
       } else {
-        const bankedRate = this.topDivider / this.tickDivider;
-        let bankedCounter = 0;
         if (this.bankedTicks > 0 && this.useBankedTicks){
-          bankedCounter = 11; // set to 10 + 1 for true / false
+          //using banked ticks makes time happen 10 times faster
+          ticksPassed *= 10;
+          this.bankedTicks -= timeDiff / TICK_INTERVAL_MS * 10 * (this.topDivider / this.tickDivider);
         }
 
         ticksPassed *= this.getTPS(this.tickDivider) / 1000 * TICK_INTERVAL_MS;
@@ -129,24 +129,10 @@ export class MainLoopService {
           this.tickCount = 36500;
         }
         let tickTime = new Date().getTime();
-        if (bankedCounter) {
-          while (!this.pause && this.tickCount >= 1 && tickTime < TICK_INTERVAL_MS + newTime) {
-            this.tick();
-            if (this.bankedTicks >= 1 && bankedCounter > 1){ // Used here to avoid overusing earned bankedticks.
-              bankedCounter--
-              this.bankedTicks -= bankedRate;
-            } else {
-              this.tickCount--;
-              bankedCounter = 11;
-            }
-            tickTime = new Date().getTime();
-          }
-        } else {
-          while (!this.pause && this.tickCount >= 1 && tickTime < TICK_INTERVAL_MS + newTime) {
-            this.tick();
-            this.tickCount--;
-            tickTime = new Date().getTime();
-          }
+        while (!this.pause && this.tickCount >= 1 && tickTime < TICK_INTERVAL_MS + newTime) {
+          this.tick();
+          this.tickCount--;
+          tickTime = new Date().getTime();
         }
       }
     }, TICK_INTERVAL_MS);

--- a/src/app/game-state/main-loop.service.ts
+++ b/src/app/game-state/main-loop.service.ts
@@ -116,6 +116,7 @@ export class MainLoopService {
       if (this.pause) {
         this.bankedTicks += ticksPassed / this.offlineDivider; // offlineDivider currently either 10 or 2.
       } else {
+        const bankedRate = this.topDivider / this.tickDivider;
         let bankedCounter = 0;
         if (this.bankedTicks > 0 && this.useBankedTicks){
           bankedCounter = 11; // set to 10 + 1 for true / false
@@ -123,7 +124,6 @@ export class MainLoopService {
 
         ticksPassed *= this.getTPS(this.tickDivider) / 1000 * TICK_INTERVAL_MS;
         this.tickCount += ticksPassed;
-        const bankedRate = this.tickDivider/this.topDivider;
         if (this.tickCount > 36500) {
           //emergency lag prevention; this should never activate normally
           this.tickCount = 36500;

--- a/src/app/statistics-panel/statistics-panel.component.ts
+++ b/src/app/statistics-panel/statistics-panel.component.ts
@@ -39,9 +39,9 @@ export class StatisticsPanelComponent implements OnInit {
         this.skipCount++;
         return;
       }
-      let currentTimestamp = new Date().getTime();
-      let timeDiff = (currentTimestamp - this.lastTimestamp) / 1000;
-      let tickDiff = this.mainLoopService.totalTicks - this.lastTickTotal;
+      const currentTimestamp = new Date().getTime();
+      const timeDiff = (currentTimestamp - this.lastTimestamp) / 1000;
+      const tickDiff = this.mainLoopService.totalTicks - this.lastTickTotal;
       if (timeDiff != 0){
         this.daysPerSecond = tickDiff / timeDiff;
       }


### PR DESCRIPTION
- Updates the way each frame tries using ticks to avoid stalling past base FPS.
- Updates bankedTicks use and gain, including higher rates with higher TPS and using one bankedTick per actual use rather than estimated use.
- Included gaining partial bankedTicks for going slower than bankedTicks gain.