### PR TITLE
Made 1e6 a valid input

### DIFF
--- a/src/app/options-modal/options-modal.component.ts
+++ b/src/app/options-modal/options-modal.component.ts
@@ -26,7 +26,7 @@ export class OptionsModalComponent {
 
   autoSellReserveChange(event: Event, autosellEntry: AutoItemEntry){
     if (!(event.target instanceof HTMLInputElement)) return;
-    autosellEntry.reserve = parseInt(event.target.value);
+    autosellEntry.reserve = Math.floor(parseFloat(event.target.value));
     if (!autosellEntry.reserve){
       autosellEntry.reserve = 0;
     }
@@ -34,7 +34,7 @@ export class OptionsModalComponent {
 
   autoUseReserveChange(event: Event, autouseEntry: AutoItemEntry){
     if (!(event.target instanceof HTMLInputElement)) return;
-    autouseEntry.reserve = parseInt(event.target.value);
+    autouseEntry.reserve = Math.floor(parseFloat(event.target.value));
     if (!autouseEntry.reserve){
       autouseEntry.reserve = 0;
     }
@@ -42,7 +42,7 @@ export class OptionsModalComponent {
 
   autoBuyLandLimitChanged(event: Event){
     if (!(event.target instanceof HTMLInputElement)) return;
-    this.homeService.autoBuyLandLimit = parseInt(event.target.value);
+    this.homeService.autoBuyLandLimit = Math.floor(parseFloat(event.target.value));
     if (!this.homeService.autoBuyLandLimit){
       this.homeService.autoBuyLandLimit = 0;
     }
@@ -50,7 +50,7 @@ export class OptionsModalComponent {
 
   autoFieldLimitChanged(event: Event){
     if (!(event.target instanceof HTMLInputElement)) return;
-    this.homeService.autoFieldLimit = parseInt(event.target.value);
+    this.homeService.autoFieldLimit = Math.floor(parseFloat(event.target.value));
     if (!this.homeService.autoFieldLimit){
       this.homeService.autoFieldLimit = 0;
     }
@@ -73,7 +73,7 @@ export class OptionsModalComponent {
 
   autoBuyReserveAmountChanged(event: Event){
     if (!(event.target instanceof HTMLInputElement)) return;
-    this.homeService.autoBuyReserveAmount = parseInt(event.target.value);
+    this.homeService.autoBuyReserveAmount = parseFloat(event.target.value);
     if (!this.homeService.autoBuyReserveAmount){
       this.homeService.autoBuyReserveAmount = 0;
     }
@@ -81,7 +81,7 @@ export class OptionsModalComponent {
 
   autoBalanceUseChanged(event: Event, balanceItem: BalanceItem){
     if (!(event.target instanceof HTMLInputElement)) return;
-    balanceItem.useNumber = parseInt(event.target.value);
+    balanceItem.useNumber = Math.floor(parseFloat(event.target.value));
     if (!balanceItem.useNumber){
       balanceItem.useNumber = 0;
     }
@@ -89,7 +89,7 @@ export class OptionsModalComponent {
 
   autoBalanceSellChanged(event: Event, balanceItem: BalanceItem){
     if (!(event.target instanceof HTMLInputElement)) return;
-    balanceItem.sellNumber = parseInt(event.target.value);
+    balanceItem.sellNumber = Math.floor(parseFloat(event.target.value));
     if (!balanceItem.sellNumber){
       balanceItem.sellNumber = 0;
     }


### PR DESCRIPTION
From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt:
"For example, although 1e3 technically encodes an integer (and will be correctly parsed to the integer 1000 by [parseFloat()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat)), parseInt("1e3", 10) returns 1, because e is not a valid numeral in base 10. Because . is not a numeral either, the return value will always be an integer."