### PR TITLE
Elevate services

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -19,6 +19,7 @@ import { ChangelogPanelComponent } from './changelog-panel/changelog-panel.compo
 import { StatisticsPanelComponent } from './statistics-panel/statistics-panel.component';
 import { HellService } from './game-state/hell.service';
 import { SaveModalComponent } from './save-modal/save-modal.component';
+import { ServicesService } from './game-state/services.service';
 
 @Pipe({name: 'floor'})
 export class FloorPipe implements PipeTransform {
@@ -115,6 +116,7 @@ export class AppComponent implements OnInit {
   }
 
   constructor(
+    private servicesService: ServicesService,
     private mainLoopService: MainLoopService,
     public gameStateService: GameStateService,
     public storeService: StoreService,
@@ -125,6 +127,7 @@ export class AppComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    this.servicesService.init();
     this.gameStateService.loadFromLocalStorage();
     this.mainLoopService.start();
   }

--- a/src/app/attributes-panel/attributes-panel.component.ts
+++ b/src/app/attributes-panel/attributes-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { FollowerManagementPanelComponent } from '../follower-management-panel/follower-management-panel.component';
 import { Character } from '../game-state/character';
@@ -11,14 +11,17 @@ import { FollowersService, Follower } from '../game-state/followers.service';
   templateUrl: './attributes-panel.component.html',
   styleUrls: ['./attributes-panel.component.less', '../app.component.less']
 })
-export class AttributesPanelComponent {
-  character: Character;
+export class AttributesPanelComponent implements OnInit {
+  character!: Character;
 
   constructor(public characterService: CharacterService,
     public dialog: MatDialog,
     public followerService: FollowersService) {
-    this.character = characterService.characterState;
    }
+
+  ngOnInit(): void {
+    this.character = this.characterService.characterState;
+  }
   
    // Preserve original property order
   originalOrder = (): number => {

--- a/src/app/equipment-panel/equipment-panel.component.ts
+++ b/src/app/equipment-panel/equipment-panel.component.ts
@@ -1,5 +1,5 @@
-import { Component } from '@angular/core';
-import { Character, EquipmentPosition, EquipmentSlots } from '../game-state/character';
+import { Component, OnInit } from '@angular/core';
+import { Character, EquipmentPosition } from '../game-state/character';
 import { CharacterService } from '../game-state/character.service';
 import { InventoryService, instanceOfEquipment, Item } from '../game-state/inventory.service';
 
@@ -8,12 +8,15 @@ import { InventoryService, instanceOfEquipment, Item } from '../game-state/inven
   templateUrl: './equipment-panel.component.html',
   styleUrls: ['./equipment-panel.component.less', '../app.component.less']
 })
-export class EquipmentPanelComponent {
-  character: Character;
+export class EquipmentPanelComponent implements OnInit {
+  character!: Character;
 
   constructor(private characterService: CharacterService,
     public inventoryService: InventoryService) {
-    this.character = characterService.characterState;
+  }
+
+  ngOnInit(): void {
+    this.character = this.characterService.characterState;
   }
 
   slotDoubleClicked(slot: EquipmentPosition, event: MouseEvent): void {

--- a/src/app/game-state/achievement.service.ts
+++ b/src/app/game-state/achievement.service.ts
@@ -653,7 +653,7 @@ export class AchievementService {
       description: "You have established an empire that will never fall, and a bloodline that will always inherit it.",
       hint: "Bloodline Empire.",
       check: () => {
-        return (this.homeService.home.type === HomeType.Capital && this.characterService.characterState.bloodlineRank >= 7);
+        return (this.homeService.home.type >= HomeType.Capital && this.characterService.characterState.bloodlineRank >= 7);
       },
       effect: () => {
         this.characterService.characterState.imperial = true;

--- a/src/app/game-state/achievement.service.ts
+++ b/src/app/game-state/achievement.service.ts
@@ -1,17 +1,7 @@
-import { Injectable, Injector } from '@angular/core';
-import { LogService } from './log.service';
-import { CharacterService } from './character.service';
-import { InventoryService } from './inventory.service';
-import { HomeService, HomeType } from './home.service';
-import { ItemRepoService } from './item-repo.service';
-import { StoreService } from './store.service';
-import { MainLoopService } from './main-loop.service';
-import { BattleService } from './battle.service';
-import { GameStateService } from './game-state.service';
-import { ActivityService } from './activity.service';
+import { Injectable } from '@angular/core';
+import { HomeType } from './home.service';
 import { ActivityType } from './activity';
-import { ImpossibleTaskService } from './impossibleTask.service';
-import { FollowersService } from './followers.service';
+import { ServicesService } from './services.service';
 
 export interface Achievement {
   name: string;
@@ -32,25 +22,14 @@ export interface AchievementProperties {
   providedIn: 'root'
 })
 export class AchievementService {
-  gameStateService?: GameStateService;
   unlockedAchievements: string[] = [];
+  achievements: Achievement[] = [];
 
+  constructor(private services: ServicesService) {}
 
-  constructor(
-    private mainLoopService: MainLoopService,
-    private injector: Injector,
-    private logService: LogService,
-    private characterService: CharacterService,
-    private inventoryService: InventoryService,
-    private itemRepoService: ItemRepoService,
-    private storeService: StoreService,
-    private battleService: BattleService,
-    private homeService: HomeService,
-    private activityService: ActivityService,
-    private followerService: FollowersService,
-    private impossibleTaskService: ImpossibleTaskService,
-  ) {
-    this.mainLoopService.longTickSubject.subscribe(() => {
+  init(): AchievementService {
+    this.populateAchievements();
+    this.services.mainLoopService.longTickSubject.subscribe(() => {
       for (const achievement of this.achievements) {
         if (!this.unlockedAchievements.includes(achievement.name)) {
           if (achievement.check()) {
@@ -59,67 +38,68 @@ export class AchievementService {
         }
       }
     });
+    return this;
   }
 
-  // important: achievement effects must be idempotent as they may be called multiple times
-  achievements: Achievement[] = [
+  populateAchievements(): void {
+  this.achievements = [
     {
       name: "Bookworm",
-      description: "You opened the manuals shop and unlocked the " + this.itemRepoService.items['restartActivityManual'].name,
+      description: "You opened the manuals shop and unlocked the " + this.services.itemRepoService.items['restartActivityManual'].name,
       hint: "There are lots of buttons in this game, maybe an aspiring immortal should press a few.",
       check: () => {
-        return this.storeService.storeOpened;
+        return this.services.storeService.storeOpened;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['restartActivityManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['restartActivityManual']);
       },
       unlocked: false
     },
     {
       name: "Played a Bit",
-      description: "You worked toward immortality for ten years across your lifetimes and unlocked the " + this.itemRepoService.items['fastPlayManual'].name,
+      description: "You worked toward immortality for ten years across your lifetimes and unlocked the " + this.services.itemRepoService.items['fastPlayManual'].name,
       hint: "Just keep playing. I'm sure this will come to an aspiring immortal eventually.",
       check: () => {
-        return this.mainLoopService.totalTicks > 3650;
+        return this.services.mainLoopService.totalTicks > 3650;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['fastPlayManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['fastPlayManual']);
       },
       unlocked: false
     },
     {
       name: "Basically an Expert",
-      description: "You worked toward immortality for one hundred years across your lifetimes and unlocked the " + this.itemRepoService.items['fasterPlayManual'].name,
+      description: "You worked toward immortality for one hundred years across your lifetimes and unlocked the " + this.services.itemRepoService.items['fasterPlayManual'].name,
       hint: "Just keep playing. I'm sure this will come to an aspiring immortal eventually.",
       check: () => {
-        return this.mainLoopService.totalTicks > 36500;
+        return this.services.mainLoopService.totalTicks > 36500;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['fasterPlayManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['fasterPlayManual']);
       },
       unlocked: false
     },
     {
       name: "Persistent Reincarnator",
-      description: "You lived one thousand years across your lifetimes and unlocked the " + this.itemRepoService.items['fastestPlayManual'].name,
+      description: "You lived one thousand years across your lifetimes and unlocked the " + this.services.itemRepoService.items['fastestPlayManual'].name,
       hint: "The millennial.",
       check: () => {
-        return this.mainLoopService.totalTicks > 365000;
+        return this.services.mainLoopService.totalTicks > 365000;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['fastestPlayManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['fastestPlayManual']);
       },
       unlocked: false
     },
     {
       name: "Veteran Cultivator",
-      description: "You lived ten thousand years across your lifetimes and unlocked the " + this.itemRepoService.items['totalPlaytimeManual'].name,
+      description: "You lived ten thousand years across your lifetimes and unlocked the " + this.services.itemRepoService.items['totalPlaytimeManual'].name,
       hint: "A long life. Myriad years.",
       check: () => {
-        return this.mainLoopService.totalTicks > 3650000;
+        return this.services.mainLoopService.totalTicks > 3650000;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['totalPlaytimeManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['totalPlaytimeManual']);
       },
       unlocked: false
     },
@@ -128,7 +108,7 @@ export class AchievementService {
       description: "You reached proficiency in blacksmithing and can now work as a Blacksmith without going through an apprenticeship (you still need the attributes for the Blacksmithing activity).",
       hint: "There are lots of activities an aspiring immortal can do on their way to immortality. Maybe you should try getting good at a few of them.",
       check: () => {
-        return this.activityService.completedApprenticeships.includes(ActivityType.Blacksmithing);
+        return this.services.activityService.completedApprenticeships.includes(ActivityType.Blacksmithing);
       },
       effect: () => {
       },
@@ -139,7 +119,7 @@ export class AchievementService {
       description: "You reached proficiency in alchemy and can now work as a Alchemist without going through an apprenticeship (you still need the attributes for the Alchemy activity).",
       hint: "There are lots of activities an aspiring immortal can do on their way to immortality. Maybe you should try getting good at a few of them.",
       check: () => {
-        return this.activityService.completedApprenticeships.includes(ActivityType.Alchemy);
+        return this.services.activityService.completedApprenticeships.includes(ActivityType.Alchemy);
       },
       effect: () => {
       },
@@ -150,7 +130,7 @@ export class AchievementService {
       description: "You reached proficiency in leatherworking and can now work as a Leatherworker without going through an apprenticeship (you still need the attributes for the Leatherworking activity).",
       hint: "There are lots of activities an aspiring immortal can do on their way to immortality. Maybe you should try getting good at a few of them.",
       check: () => {
-        return this.activityService.completedApprenticeships.includes(ActivityType.Leatherworking);
+        return this.services.activityService.completedApprenticeships.includes(ActivityType.Leatherworking);
       },
       effect: () => {
       },
@@ -161,7 +141,7 @@ export class AchievementService {
       description: "You reached proficiency in woodworking and can now work as a Woodworker without going through an apprenticeship (you still need the attributes for the Woodworking activity).",
       hint: "There are lots of activities an aspiring immortal can do on their way to immortality. Maybe you should try getting good at a few of them.",
       check: () => {
-        return this.activityService.completedApprenticeships.includes(ActivityType.Woodworking);
+        return this.services.activityService.completedApprenticeships.includes(ActivityType.Woodworking);
       },
       effect: () => {
       },
@@ -172,7 +152,7 @@ export class AchievementService {
       description: "You got a taste of those sweet, sweet empowerment pills and want more.",
       hint: "Master of all.",
       check: () => {
-        return this.characterService.characterState.empowermentFactor > 1;
+        return this.services.characterService.characterState.empowermentFactor > 1;
       },
       effect: () => { //TODO: Create a downside to taking empowerment pills, maybe post-Death
       },
@@ -184,7 +164,7 @@ export class AchievementService {
       description: "You got every last drop you could out of those pills and now you feel nothing from them. At least they didn't kill you or do lasting harm, right?",
       hint: "D.A.R.E.",
       check: () => {
-        return this.characterService.characterState.empowermentFactor >= 1953.65;
+        return this.services.characterService.characterState.empowermentFactor >= 1953.65;
       },
       effect: () => { //TODO: Create a downside to taking HUGE NUMBERS of empowerment pills, maybe in Hell?
       },
@@ -192,295 +172,295 @@ export class AchievementService {
     },
     {
       name: "This Sparks Joy",
-      description: "You used 888 items and unlocked the " + this.itemRepoService.items['autoUseManual'].name,
+      description: "You used 888 items and unlocked the " + this.services.itemRepoService.items['autoUseManual'].name,
       hint: "Immortals should know the potential of the things they use.",
       check: () => {
-        return this.inventoryService.lifetimeUsedItems >= 888;
+        return this.services.inventoryService.lifetimeUsedItems >= 888;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['autoUseManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['autoUseManual']);
       },
       unlocked: false
     },
     {
       name: "This Does Not Spark Joy",
-      description: "You filled your entire inventory and unlocked the " + this.itemRepoService.items['autoSellManual'].name,
+      description: "You filled your entire inventory and unlocked the " + this.services.itemRepoService.items['autoSellManual'].name,
       hint: "So much stuff.",
       check: () => {
-        return this.inventoryService.openInventorySlots() === 0;
+        return this.services.inventoryService.openInventorySlots() === 0;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['autoSellManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['autoSellManual']);
       },
       unlocked: false
     },
     {
       name: "Waster",
-      description: "You throw away 10,000 items and unlocked the " + this.itemRepoService.items['betterStorageManual'].name,
+      description: "You throw away 10,000 items and unlocked the " + this.services.itemRepoService.items['betterStorageManual'].name,
       hint: "Too much stuff.",
       check: () => {
-        return this.inventoryService.thrownAwayItems >= 10000;
+        return this.services.inventoryService.thrownAwayItems >= 10000;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['betterStorageManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['betterStorageManual']);
       },
       unlocked: false
     },
     {
       name: "Landfill",
-      description: "You throw away 100,000 items and unlocked the " + this.itemRepoService.items['evenBetterStorageManual'].name,
+      description: "You throw away 100,000 items and unlocked the " + this.services.itemRepoService.items['evenBetterStorageManual'].name,
       hint: "Way, way too much stuff.",
       check: () => {
-        return this.inventoryService.maxStackSize >= 1000 && this.inventoryService.thrownAwayItems >= 100000;
+        return this.services.inventoryService.maxStackSize >= 1000 && this.services.inventoryService.thrownAwayItems >= 100000;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['evenBetterStorageManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['evenBetterStorageManual']);
       },
       unlocked: false
     },
     {
       name: "Hoarder",
-      description: "You really love holding vast amounts of materials and unlocked the " + this.itemRepoService.items['bestStorageManual'].name,
+      description: "You really love holding vast amounts of materials and unlocked the " + this.services.itemRepoService.items['bestStorageManual'].name,
       hint: "Just stop already, it's too much. Why would an aspiring immortal need this much?",
       check: () => {
-        return this.inventoryService.maxStackSize >= 10000 && this.inventoryService.thrownAwayItems >= 1000000;
+        return this.services.inventoryService.maxStackSize >= 10000 && this.services.inventoryService.thrownAwayItems >= 1000000;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['bestStorageManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['bestStorageManual']);
       },
       unlocked: false
     },
     {
       name: "All Things In Moderation",
       hint: "Immortals know what to use and what to toss.",
-      description: "You sold and used 8888 items and unlocked the " + this.itemRepoService.items['autoBalanceManual'].name,
+      description: "You sold and used 8888 items and unlocked the " + this.services.itemRepoService.items['autoBalanceManual'].name,
       check: () => {
-        return this.inventoryService.lifetimeUsedItems >= 8888 && this.inventoryService.lifetimeSoldItems >= 8888;
+        return this.services.inventoryService.lifetimeUsedItems >= 8888 && this.services.inventoryService.lifetimeSoldItems >= 8888;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['autoBalanceManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['autoBalanceManual']);
       },
       unlocked: false
     },
     {
       name: "Land Rush",
-      description: "You owned 520 plots of land and unlocked the " + this.itemRepoService.items['autoBuyLandManual'].name,
+      description: "You owned 520 plots of land and unlocked the " + this.services.itemRepoService.items['autoBuyLandManual'].name,
       hint: "Immortals are known for their vast real estate holdings.",
       check: () => {
-        return this.homeService.land >= 520;
+        return this.services.homeService.land >= 520;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['autoBuyLandManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['autoBuyLandManual']);
       },
       unlocked: false
     },
     {
       name: "Real Housewives of Immortality",
-      description: "You acquired a very fine home and unlocked the " + this.itemRepoService.items['autoBuyHomeManual'].name,
+      description: "You acquired a very fine home and unlocked the " + this.services.itemRepoService.items['autoBuyHomeManual'].name,
       hint: "Immortals value a good home.",
       check: () => {
-        return this.homeService.homeValue >= HomeType.CourtyardHouse;
+        return this.services.homeService.homeValue >= HomeType.CourtyardHouse;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['autoBuyHomeManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['autoBuyHomeManual']);
       },
       unlocked: false
     },
     {
       name: "Off to Ikea",
-      description: "You filled all your furniture slots and unlocked the " + this.itemRepoService.items['autoBuyFurnitureManual'].name,
+      description: "You filled all your furniture slots and unlocked the " + this.services.itemRepoService.items['autoBuyFurnitureManual'].name,
       hint: "Immortals have discerning taste in furnishings.",
       check: () => {
-        return this.homeService.furniture.bathtub !== null &&
-          this.homeService.furniture.bed !== null &&
-          this.homeService.furniture.kitchen !== null &&
-          this.homeService.furniture.workbench !== null;
+        return this.services.homeService.furniture.bathtub !== null &&
+          this.services.homeService.furniture.bed !== null &&
+          this.services.homeService.furniture.kitchen !== null &&
+          this.services.homeService.furniture.workbench !== null;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['autoBuyFurnitureManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['autoBuyFurnitureManual']);
       },
       unlocked: false
     },
     {
       name: "Time to Buy a Tractor",
-      description: "You plowed 888 fields and unlocked the " + this.itemRepoService.items['autoFieldManual'].name,
+      description: "You plowed 888 fields and unlocked the " + this.services.itemRepoService.items['autoFieldManual'].name,
       hint: "An aspiring immortal should have vast tracts of fertile land.",
       check: () => {
-        return this.homeService.fields.length + this.homeService.extraFields >= 888;
+        return this.services.homeService.fields.length + this.services.homeService.extraFields >= 888;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['autoFieldManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['autoFieldManual']);
       },
       unlocked: false
     },
     {
       name: "Industrial Revolution",
-      description: "You've found all the basic autobuyers and unlocked the " + this.itemRepoService.items['autoBuyerSettingsManual'].name,
+      description: "You've found all the basic autobuyers and unlocked the " + this.services.itemRepoService.items['autoBuyerSettingsManual'].name,
       hint: "Become really, really lazy",
       check: () => {
-        return this.homeService.autoBuyHomeUnlocked &&
-          this.homeService.autoBuyLandUnlocked &&
-          this.homeService.autoFieldUnlocked &&
-          this.homeService.autoBuyFurnitureUnlocked
+        return this.services.homeService.autoBuyHomeUnlocked &&
+          this.services.homeService.autoBuyLandUnlocked &&
+          this.services.homeService.autoFieldUnlocked &&
+          this.services.homeService.autoBuyFurnitureUnlocked
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['autoBuyerSettingsManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['autoBuyerSettingsManual']);
       },
       unlocked: false
     },
     {
       name: "Guzzler",
-      description: "You drank 88 potions and unlocked the " + this.itemRepoService.items['autoPotionManual'].name,
+      description: "You drank 88 potions and unlocked the " + this.services.itemRepoService.items['autoPotionManual'].name,
       hint: "Glug, glug, glug.",
       check: () => {
-        return this.inventoryService.lifetimePotionsUsed >= 88;
+        return this.services.inventoryService.lifetimePotionsUsed >= 88;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['autoPotionManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['autoPotionManual']);
       },
       unlocked: false
     },
     {
       name: "Junkie",
-      description: "You took 131 pills and unlocked the " + this.itemRepoService.items['autoPillManual'].name,
+      description: "You took 131 pills and unlocked the " + this.services.itemRepoService.items['autoPillManual'].name,
       hint: "An aspiring immortal should take the red one. Take it over and over.",
       check: () => {
-        return this.inventoryService.lifetimePillsUsed >= 131;
+        return this.services.inventoryService.lifetimePillsUsed >= 131;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['autoPillManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['autoPillManual']);
       },
       unlocked: false
     },
     {
       name: "Monster Slayer",
-      description: "You killed 131 monsters and unlocked the " + this.itemRepoService.items['autoTroubleManual'].name,
+      description: "You killed 131 monsters and unlocked the " + this.services.itemRepoService.items['autoTroubleManual'].name,
       hint: "An aspiring immortal bravely faces down their foes.",
       check: () => {
-        return this.battleService.troubleKills >= 131;
+        return this.services.battleService.troubleKills >= 131;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['autoTroubleManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['autoTroubleManual']);
       },
       unlocked: false
     },
     {
       name: "Weapons Master",
-      description: "You wielded powerful weapons of both metal and wood and unlocked the " + this.itemRepoService.items['autoWeaponMergeManual'].name,
+      description: "You wielded powerful weapons of both metal and wood and unlocked the " + this.services.itemRepoService.items['autoWeaponMergeManual'].name,
       hint: "Left and right.",
       check: () => {
-        if (this.characterService.characterState.equipment?.rightHand?.weaponStats &&
-          this.characterService.characterState.equipment?.rightHand?.weaponStats.baseDamage >= 60 &&
-          this.characterService.characterState.equipment?.leftHand?.weaponStats &&
-          this.characterService.characterState.equipment?.leftHand?.weaponStats.baseDamage >= 60
+        if (this.services.characterService.characterState.equipment?.rightHand?.weaponStats &&
+          this.services.characterService.characterState.equipment?.rightHand?.weaponStats.baseDamage >= 60 &&
+          this.services.characterService.characterState.equipment?.leftHand?.weaponStats &&
+          this.services.characterService.characterState.equipment?.leftHand?.weaponStats.baseDamage >= 60
         ) {
           return true;
         }
         return false;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['autoWeaponMergeManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['autoWeaponMergeManual']);
       },
       unlocked: false
     },
     {
       name: "Practically Invincible",
-      description: "You equipped yourself with powerful armor and unlocked the " + this.itemRepoService.items['autoArmorMergeManual'].name,
+      description: "You equipped yourself with powerful armor and unlocked the " + this.services.itemRepoService.items['autoArmorMergeManual'].name,
       hint: "Suit up.",
       check: () => {
-        if (this.characterService.characterState.equipment?.head?.armorStats &&
-          this.characterService.characterState.equipment?.head?.armorStats.defense >= 60 &&
-          this.characterService.characterState.equipment?.body?.armorStats &&
-          this.characterService.characterState.equipment?.body?.armorStats.defense >= 60 &&
-          this.characterService.characterState.equipment?.legs?.armorStats &&
-          this.characterService.characterState.equipment?.legs?.armorStats.defense >= 60 &&
-          this.characterService.characterState.equipment?.feet?.armorStats &&
-          this.characterService.characterState.equipment?.feet?.armorStats.defense >= 60) {
+        if (this.services.characterService.characterState.equipment?.head?.armorStats &&
+          this.services.characterService.characterState.equipment?.head?.armorStats.defense >= 60 &&
+          this.services.characterService.characterState.equipment?.body?.armorStats &&
+          this.services.characterService.characterState.equipment?.body?.armorStats.defense >= 60 &&
+          this.services.characterService.characterState.equipment?.legs?.armorStats &&
+          this.services.characterService.characterState.equipment?.legs?.armorStats.defense >= 60 &&
+          this.services.characterService.characterState.equipment?.feet?.armorStats &&
+          this.services.characterService.characterState.equipment?.feet?.armorStats.defense >= 60) {
           return true;
         }
         return false;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['autoArmorMergeManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['autoArmorMergeManual']);
       },
       unlocked: false
     },
     {
       name: "Gemologist",
-      description: "You acquired 88 gems and unlocked the " + this.itemRepoService.items['useSpiritGemManual'].name,
+      description: "You acquired 88 gems and unlocked the " + this.services.itemRepoService.items['useSpiritGemManual'].name,
       hint: "Ooh, shiny.",
       check: () => {
-        return this.battleService.troubleKills > 88;
+        return this.services.battleService.troubleKills > 88;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['useSpiritGemManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['useSpiritGemManual']);
       },
       unlocked: false
     },
     {
       name: "Ingredient Snob",
-      description: "You achieved a deep understanding of herbs and unlocked the " + this.itemRepoService.items['bestHerbsManual'].name,
+      description: "You achieved a deep understanding of herbs and unlocked the " + this.services.itemRepoService.items['bestHerbsManual'].name,
       hint: "An aspiring immortal should take the red one. Take it over and over.",
       check: () => {
-        return this.characterService.characterState.attributes.woodLore.value > 1024 &&
-          this.characterService.characterState.attributes.waterLore.value > 1024;
+        return this.services.characterService.characterState.attributes.woodLore.value > 1024 &&
+          this.services.characterService.characterState.attributes.waterLore.value > 1024;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['bestHerbsManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['bestHerbsManual']);
       },
       unlocked: false
     },
     {
       name: "Wood Snob",
-      description: "You achieved a deep understanding of wood and unlocked the " + this.itemRepoService.items['bestWoodManual'].name,
+      description: "You achieved a deep understanding of wood and unlocked the " + this.services.itemRepoService.items['bestWoodManual'].name,
       hint: "There are lots of activities an aspiring immortal can do on their way to immortality. Maybe you should try getting good at a few of them.",
       check: () => {
-        return this.characterService.characterState.attributes.woodLore.value > 1024 &&
-          this.characterService.characterState.attributes.intelligence.value > 1024;
+        return this.services.characterService.characterState.attributes.woodLore.value > 1024 &&
+          this.services.characterService.characterState.attributes.intelligence.value > 1024;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['bestWoodManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['bestWoodManual']);
       },
       unlocked: false
     },
     {
       name: "Ore Snob",
       displayName: "Smelting Snob",
-      description: "You achieved a deep understanding of digging and smelting metal and unlocked the " + this.itemRepoService.items['bestOreManual'].name,
+      description: "You achieved a deep understanding of digging and smelting metal and unlocked the " + this.services.itemRepoService.items['bestOreManual'].name,
       hint: "There are lots of activities an aspiring immortal can do on their way to immortality. Maybe you should try getting good at a few of them.",
       check: () => {
-        return this.characterService.characterState.attributes.metalLore.value > 1024 &&
-          this.characterService.characterState.attributes.earthLore.value > 1024;
+        return this.services.characterService.characterState.attributes.metalLore.value > 1024 &&
+          this.services.characterService.characterState.attributes.earthLore.value > 1024;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['bestOreManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['bestOreManual']);
       },
       unlocked: false
     },
     {
       name: "Hide Snob",
       displayName: "Hunting Snob",
-      description: "You achieved a deep understanding of hunting and gathering hides and unlocked the " + this.itemRepoService.items['bestHidesManual'].name,
+      description: "You achieved a deep understanding of hunting and gathering hides and unlocked the " + this.services.itemRepoService.items['bestHidesManual'].name,
       hint: "There are lots of activities an aspiring immortal can do on their way to immortality. Maybe you should try getting good at a few of them.",
       check: () => {
-        return this.characterService.characterState.attributes.animalHandling.value > 1024 &&
-          this.characterService.characterState.attributes.speed.value > 1024;
+        return this.services.characterService.characterState.attributes.animalHandling.value > 1024 &&
+          this.services.characterService.characterState.attributes.speed.value > 1024;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['bestHidesManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['bestHidesManual']);
       },
       unlocked: false
 
     },
     {
       name: "Gem Snob",
-      description: "You have sold 888 gems and unlocked the " + this.itemRepoService.items['bestGemsManual'].name,
+      description: "You have sold 888 gems and unlocked the " + this.services.itemRepoService.items['bestGemsManual'].name,
       hint: "I hear the market for fine jewelry is so hot right now.",
       check: () => {
-        return this.inventoryService.lifetimeGemsSold >= 888;
+        return this.services.inventoryService.lifetimeGemsSold >= 888;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['bestGemsManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['bestGemsManual']);
       },
       unlocked: false
     },
@@ -489,7 +469,7 @@ export class AchievementService {
       description: "Your family has unlocked the secrets of compound interest. You probably never have to worry about money again.",
       hint: "Family first. Especially in matters of money.",
       check: () => {
-        return this.characterService.characterState.bloodlineRank >= 4;
+        return this.services.characterService.characterState.bloodlineRank >= 4;
       },
       effect: () => {
       },
@@ -500,7 +480,7 @@ export class AchievementService {
       description: "You filled up your purse, your wall safe, the box under your bed, and a giant money pit in the backyard. You just can't hold any more money.",
       hint: "How rich can you get?",
       check: () => {
-        return this.characterService.characterState.money >= this.characterService.characterState.maxMoney - 1e21; //not exactly max in case this gets checked at a bad time
+        return this.services.characterService.characterState.money >= this.services.characterService.characterState.maxMoney - 1e21; //not exactly max in case this gets checked at a bad time
       },
       effect: () => {
       },
@@ -511,10 +491,10 @@ export class AchievementService {
       description: "You've gone through eight cycles of reincarnation and come to understand the value of grandfathers.",
       hint: "Just keep playing. I'm sure this will come to an aspiring immortal eventually.",
       check: () => {
-        return this.characterService.characterState.totalLives > 8;
+        return this.services.characterService.characterState.totalLives > 8;
       },
       effect: () => {
-        this.homeService.grandfatherTent = true;
+        this.services.homeService.grandfatherTent = true;
       },
       unlocked: false
     },
@@ -523,10 +503,10 @@ export class AchievementService {
       description: "You've worked 888 days of odd jobs and come to understand the value of fathers.",
       hint: "Just keep playing. I'm sure this will come to an aspiring immortal eventually.",
       check: () => {
-        return this.activityService.oddJobDays > 888;
+        return this.services.activityService.oddJobDays > 888;
       },
       effect: () => {
-        this.characterService.fatherGift = true;
+        this.services.characterService.fatherGift = true;
       },
       unlocked: false
     },
@@ -535,10 +515,10 @@ export class AchievementService {
       description: "You've done 888 days of begging and come to understand the value of mothers.",
       hint: "Just keep playing. I'm sure this will come to an aspiring immortal eventually.",
       check: () => {
-        return this.activityService.beggingDays > 888;
+        return this.services.activityService.beggingDays > 888;
       },
       effect: () => {
-        this.inventoryService.motherGift = true;
+        this.services.inventoryService.motherGift = true;
       },
       unlocked: false
     },
@@ -547,51 +527,51 @@ export class AchievementService {
       description: "You've developed spirituality and come to understand the value of grandmothers.",
       hint: "Just keep playing. I'm sure this will come to an aspiring immortal eventually.",
       check: () => {
-        return this.characterService.characterState.attributes.spirituality.value > 0;
+        return this.services.characterService.characterState.attributes.spirituality.value > 0;
       },
       effect: () => {
-        this.inventoryService.grandmotherGift = true;
+        this.services.inventoryService.grandmotherGift = true;
       },
       unlocked: false
     },
     {
       name: "Weapons Grandmaster",
-      description: "You wielded epic weapons of both metal and wood and unlocked the " + this.itemRepoService.items['bestWeaponManual'].name,
+      description: "You wielded epic weapons of both metal and wood and unlocked the " + this.services.itemRepoService.items['bestWeaponManual'].name,
       hint: "Power level 10,000!",
       check: () => {
-        if (this.characterService.characterState.equipment?.rightHand?.weaponStats &&
-          this.characterService.characterState.equipment?.rightHand?.weaponStats.baseDamage >= 8888 &&
-          this.characterService.characterState.equipment?.leftHand?.weaponStats &&
-          this.characterService.characterState.equipment?.leftHand?.weaponStats.baseDamage >= 8888
+        if (this.services.characterService.characterState.equipment?.rightHand?.weaponStats &&
+          this.services.characterService.characterState.equipment?.rightHand?.weaponStats.baseDamage >= 8888 &&
+          this.services.characterService.characterState.equipment?.leftHand?.weaponStats &&
+          this.services.characterService.characterState.equipment?.leftHand?.weaponStats.baseDamage >= 8888
         ) {
           return true;
         }
         return false;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['bestWeaponManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['bestWeaponManual']);
       },
       unlocked: false
     },
     {
       name: "Tank!",
-      description: "You armored yourself with epic defenses and unlocked the " + this.itemRepoService.items['bestArmorManual'].name,
+      description: "You armored yourself with epic defenses and unlocked the " + this.services.itemRepoService.items['bestArmorManual'].name,
       hint: "Don't hurt me!",
       check: () => {
-        if (this.characterService.characterState.equipment?.head?.armorStats &&
-          this.characterService.characterState.equipment?.head?.armorStats.defense >= 8888 &&
-          this.characterService.characterState.equipment?.body?.armorStats &&
-          this.characterService.characterState.equipment?.body?.armorStats.defense >= 8888 &&
-          this.characterService.characterState.equipment?.legs?.armorStats &&
-          this.characterService.characterState.equipment?.legs?.armorStats.defense >= 8888 &&
-          this.characterService.characterState.equipment?.feet?.armorStats &&
-          this.characterService.characterState.equipment?.feet?.armorStats.defense >= 8888) {
+        if (this.services.characterService.characterState.equipment?.head?.armorStats &&
+          this.services.characterService.characterState.equipment?.head?.armorStats.defense >= 8888 &&
+          this.services.characterService.characterState.equipment?.body?.armorStats &&
+          this.services.characterService.characterState.equipment?.body?.armorStats.defense >= 8888 &&
+          this.services.characterService.characterState.equipment?.legs?.armorStats &&
+          this.services.characterService.characterState.equipment?.legs?.armorStats.defense >= 8888 &&
+          this.services.characterService.characterState.equipment?.feet?.armorStats &&
+          this.services.characterService.characterState.equipment?.feet?.armorStats.defense >= 8888) {
           return true;
         }
         return false;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['bestArmorManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['bestArmorManual']);
       },
       unlocked: false
     },
@@ -600,23 +580,23 @@ export class AchievementService {
       description: "Enlightenment! You have achieved a permanent and deep understanding of elemental balance with your high, balanced levels of lore in each of the five elements. Mana is now unlocked for all future lives.",
       hint: "Seek the balance of the dao.",
       check: () => {
-        const fireLore = this.characterService.characterState.attributes.fireLore.value;
-        const earthLore = this.characterService.characterState.attributes.earthLore.value;
-        const woodLore = this.characterService.characterState.attributes.woodLore.value;
-        const waterLore = this.characterService.characterState.attributes.waterLore.value;
-        const metalLore = this.characterService.characterState.attributes.metalLore.value; //Reduce the bulk
+        const fireLore = this.services.characterService.characterState.attributes.fireLore.value;
+        const earthLore = this.services.characterService.characterState.attributes.earthLore.value;
+        const woodLore = this.services.characterService.characterState.attributes.woodLore.value;
+        const waterLore = this.services.characterService.characterState.attributes.waterLore.value;
+        const metalLore = this.services.characterService.characterState.attributes.metalLore.value; //Reduce the bulk
 
         const lowValue = Math.min(metalLore, waterLore, woodLore, earthLore, fireLore);
         const highValue = Math.max(metalLore, waterLore, woodLore, earthLore, fireLore);
         return lowValue >= 1000 && highValue <= lowValue * 1.21; // 1.1 * 1.1 = 1.21
       },
       effect: () => {
-        this.characterService.characterState.manaUnlocked = true;
-        if (this.characterService.characterState.status.mana.max === 0) {
-          this.characterService.characterState.status.mana.max = 1;
-          this.characterService.characterState.status.mana.value = 1;
+        this.services.characterService.characterState.manaUnlocked = true;
+        if (this.services.characterService.characterState.status.mana.max === 0) {
+          this.services.characterService.characterState.status.mana.max = 1;
+          this.services.characterService.characterState.status.mana.value = 1;
         }
-        this.activityService.reloadActivities();
+        this.services.activityService.reloadActivities();
       },
       unlocked: false
     },
@@ -625,12 +605,12 @@ export class AchievementService {
       description: "You have become powerful enough that you may now start attracting followers.",
       hint: "Ascension has its privileges.",
       check: () => {
-        return (this.characterService.soulCoreRank() >= 1) &&
-          (this.characterService.meridianRank() >= 1) &&
-          this.characterService.characterState.bloodlineRank >= 1;
+        return (this.services.characterService.soulCoreRank() >= 1) &&
+          (this.services.characterService.meridianRank() >= 1) &&
+          this.services.characterService.characterState.bloodlineRank >= 1;
       },
       effect: () => {
-        this.followerService.followersUnlocked = true;
+        this.services.followerService.followersUnlocked = true;
       },
       unlocked: false
     },
@@ -639,12 +619,12 @@ export class AchievementService {
       description: "You have achieved incredible power and are ready to begin taking on impossible tasks.",
       hint: "No one can exceed the limits of humanity. It can't be done.",
       check: () => {
-        return (this.characterService.soulCoreRank() >= 9) &&
-          (this.characterService.meridianRank() >= 9) &&
-          this.characterService.characterState.bloodlineRank >= 5;
+        return (this.services.characterService.soulCoreRank() >= 9) &&
+          (this.services.characterService.meridianRank() >= 9) &&
+          this.services.characterService.characterState.bloodlineRank >= 5;
       },
       effect: () => {
-        this.impossibleTaskService.impossibleTasksUnlocked = true;
+        this.services.impossibleTaskService.impossibleTasksUnlocked = true;
       },
       unlocked: false
     },
@@ -653,10 +633,10 @@ export class AchievementService {
       description: "You have established an empire that will never fall, and a bloodline that will always inherit it.",
       hint: "Bloodline Empire.",
       check: () => {
-        return (this.homeService.home.type >= HomeType.Capital && this.characterService.characterState.bloodlineRank >= 7);
+        return (this.services.homeService.home.type >= HomeType.Capital && this.services.characterService.characterState.bloodlineRank >= 7);
       },
       effect: () => {
-        this.characterService.characterState.imperial = true;
+        this.services.characterService.characterState.imperial = true;
       },
       unlocked: false
     },
@@ -665,7 +645,7 @@ export class AchievementService {
       description: "You have broken past human limits and improve constantly! What new fate awaits you?",
       hint: "999",
       check: () => {
-        return (this.characterService.characterState.bloodlineRank >= 9);
+        return (this.services.characterService.characterState.bloodlineRank >= 9);
       },
       effect: () => {
       },
@@ -676,18 +656,18 @@ export class AchievementService {
       description: "You have balanced your powerful mind and body and unlocked the ability to use your mana to strike down your enemies.",
       hint: "The dao embraces all things in perfect harmony.",
       check: () => {
-        const speed = this.characterService.characterState.attributes.speed.value;
-        const toughness = this.characterService.characterState.attributes.toughness.value;
-        const charisma = this.characterService.characterState.attributes.charisma.value;
-        const intelligence = this.characterService.characterState.attributes.intelligence.value;
-        const strength = this.characterService.characterState.attributes.strength.value; //Reduce the bulk
+        const speed = this.services.characterService.characterState.attributes.speed.value;
+        const toughness = this.services.characterService.characterState.attributes.toughness.value;
+        const charisma = this.services.characterService.characterState.attributes.charisma.value;
+        const intelligence = this.services.characterService.characterState.attributes.intelligence.value;
+        const strength = this.services.characterService.characterState.attributes.strength.value; //Reduce the bulk
 
         const lowValue = Math.min(speed, toughness, charisma, intelligence, strength);
         const highValue = Math.max(speed, toughness, charisma, intelligence, strength);
         return lowValue >= 1000000 && highValue <= lowValue * 1.21; // 1.1 * 1.1 = 1.21
       },
       effect: () => {
-        this.battleService.manaAttackUnlocked = true;
+        this.services.battleService.manaAttackUnlocked = true;
       },
       unlocked: false
     },
@@ -696,31 +676,31 @@ export class AchievementService {
       description: "You have balanced your powerful spirit with your mind and body. You unlocked the ability to use your mana to protect yourself.",
       hint: "The dao embraces all things in perfect harmony.",
       check: () => {
-        const spirituality = this.characterService.characterState.attributes.spirituality.value;
-        const speed = this.characterService.characterState.attributes.speed.value;
-        const toughness = this.characterService.characterState.attributes.toughness.value;
-        const charisma = this.characterService.characterState.attributes.charisma.value;
-        const intelligence = this.characterService.characterState.attributes.intelligence.value;
-        const strength = this.characterService.characterState.attributes.strength.value; //Reduce the bulk
+        const spirituality = this.services.characterService.characterState.attributes.spirituality.value;
+        const speed = this.services.characterService.characterState.attributes.speed.value;
+        const toughness = this.services.characterService.characterState.attributes.toughness.value;
+        const charisma = this.services.characterService.characterState.attributes.charisma.value;
+        const intelligence = this.services.characterService.characterState.attributes.intelligence.value;
+        const strength = this.services.characterService.characterState.attributes.strength.value; //Reduce the bulk
 
         const lowValue = Math.min(speed, toughness, charisma, intelligence, strength, spirituality);
         const highValue = Math.max(speed, toughness, charisma, intelligence, strength, spirituality);
         return lowValue >= 1000000 && highValue <= lowValue * 1.21; // 1.1 * 1.1 = 1.21
       },
       effect: () => {
-        this.battleService.manaShieldUnlocked = true;
+        this.services.battleService.manaShieldUnlocked = true;
       },
       unlocked: false
     },
     {
       name: "Disposable Followers",
-      description: "You have recruited so many people you can now freely dismiss followers using the " + this.itemRepoService.items['followerAutoDismissManual'].name,
+      description: "You have recruited so many people you can now freely dismiss followers using the " + this.services.itemRepoService.items['followerAutoDismissManual'].name,
       hint: "The One Hundred Companions.",
       check: () => {
-        return this.followerService.followersRecruited >= 100;
+        return this.services.followerService.followersRecruited >= 100;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['followerAutoDismissManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['followerAutoDismissManual']);
       },
       unlocked: false
     },
@@ -729,10 +709,10 @@ export class AchievementService {
       description: "One of your followers has trained under you so long they have nothing else to learn. In an epiphany you realized how to double your new followers' lifespan.",
       hint: "Endless training.",
       check: () => {
-        return this.followerService.highestLevel >= 100;
+        return this.services.followerService.highestLevel >= 100;
       },
       effect: () => {
-        this.followerService.followerLifespanDoubled = true;
+        this.services.followerService.followerLifespanDoubled = true;
       },
       unlocked: false
     },
@@ -741,58 +721,58 @@ export class AchievementService {
       description: "You have developed enough spirituality to ascend.",
       hint: "Only with spiritual development can you ascend to higher states.",
       check: () => {
-        return this.characterService.characterState.attributes.spirituality.value >= 10;
+        return this.services.characterService.characterState.attributes.spirituality.value >= 10;
       },
       effect: () => {
-        this.characterService.characterState.ascensionUnlocked = true;
+        this.services.characterService.characterState.ascensionUnlocked = true;
       },
       unlocked: false
     },
     {
       name: "I don't want to go.",
-      description: "You have lived many lives and unlocked the " + this.itemRepoService.items['autoPauseSettingsManual'].name,
+      description: "You have lived many lives and unlocked the " + this.services.itemRepoService.items['autoPauseSettingsManual'].name,
       hint: "Just keep playing. I'm sure this will come to an aspiring immortal eventually.",
       check: () => {
-        return this.characterService.characterState.totalLives >= 48 && this.mainLoopService.totalTicks > 18250;
+        return this.services.characterService.characterState.totalLives >= 48 && this.services.mainLoopService.totalTicks > 18250;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['autoPauseSettingsManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['autoPauseSettingsManual']);
       },
       unlocked: false
     },
     {
       name: "Breaks are Good",
-      description: "You have collected two hour's worth of offline ticks and unlocked the " + this.itemRepoService.items['bankedTicksEfficiencyManual'].name,
+      description: "You have collected two hour's worth of offline ticks and unlocked the " + this.services.itemRepoService.items['bankedTicksEfficiencyManual'].name,
       hint: "Take a day off from cultivating.", //it takes 20h to get
       check: () => {
-        return this.mainLoopService.bankedTicks > 2 * 60 * 60 * 40; //there are 40 ticks a second
+        return this.services.mainLoopService.bankedTicks > 2 * 60 * 60 * 40; //there are 40 ticks a second
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['bankedTicksEfficiencyManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['bankedTicksEfficiencyManual']);
       },
       unlocked: false
     },
     {
       name: "Breaks are Bad",
-      description: "You died from overwork performing an activity without necessary rest and unlocked the " + this.itemRepoService.items['autoRestManual'].name,
+      description: "You died from overwork performing an activity without necessary rest and unlocked the " + this.services.itemRepoService.items['autoRestManual'].name,
       hint: "There's no time to rest, cultivating is life.",
       check: () => {
-        return this.activityService.activityDeath || this.characterService.characterState.immortal;
+        return this.services.activityService.activityDeath || this.services.characterService.characterState.immortal;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['autoRestManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['autoRestManual']);
       },
       unlocked: false
     },
     {
       name: "Still Spry",
-      description: "You have lived to be 300 years old and unlocked the " + this.itemRepoService.items['ageSpeedManual'].name,
+      description: "You have lived to be 300 years old and unlocked the " + this.services.itemRepoService.items['ageSpeedManual'].name,
       hint: "One step to becoming immortal is to live longer.",
       check: () => {
-        return this.characterService.characterState.age > 300 * 365;
+        return this.services.characterService.characterState.age > 300 * 365;
       },
       effect: () => {
-        this.storeService.unlockManual(this.itemRepoService.items['ageSpeedManual']);
+        this.services.storeService.unlockManual(this.services.itemRepoService.items['ageSpeedManual']);
       },
       unlocked: false
     },
@@ -801,10 +781,10 @@ export class AchievementService {
       description: "Congratulations! You are now immortal.",
       hint: "Name of the game.",
       check: () => {
-        return this.characterService.characterState.immortal;
+        return this.services.characterService.characterState.immortal;
       },
       effect: () => { 
-        this.activityService.reloadActivities();
+        this.services.activityService.reloadActivities();
       },
       unlocked: false
     },
@@ -813,10 +793,10 @@ export class AchievementService {
       description: "You've sorted through so many applicants that you can now always find followers you want.",
       hint: "You didn't really want one thousand scouts, did you?",
       check: () => {
-        return this.followerService.totalDismissed > 888;
+        return this.services.followerService.totalDismissed > 888;
       },
       effect: () => { 
-        this.followerService.onlyWantedFollowers = true;
+        this.services.followerService.onlyWantedFollowers = true;
       },
       unlocked: false
     },
@@ -825,7 +805,7 @@ export class AchievementService {
       description: "You found him.",
       hint: "Can we fix it?",
       check: () => {
-        for (const follower of this.followerService.followers){
+        for (const follower of this.services.followerService.followers){
           if ((follower.name === "Robert" || follower.name === "Bob") && follower.job === "builder"){
             return true;
           }
@@ -842,8 +822,8 @@ export class AchievementService {
       description: "You have crafted the mightiest stick. Grandmother would be so proud.",
       hint: "The best stick.",
       check: () => {
-        if (this.characterService.characterState.equipment.leftHand?.name === "Grandmother's Walking Stick"){
-          if ((this.characterService.characterState.equipment.leftHand.weaponStats?.baseDamage || 0) > 1e9){
+        if (this.services.characterService.characterState.equipment.leftHand?.name === "Grandmother's Walking Stick"){
+          if ((this.services.characterService.characterState.equipment.leftHand.weaponStats?.baseDamage || 0) > 1e9){
             return true;
           }
         }
@@ -856,17 +836,14 @@ export class AchievementService {
     },
     
   ];
+}
 
   unlockAchievement(achievement: Achievement, newAchievement: boolean) {
     if (newAchievement) {
       this.unlockedAchievements.push(achievement.name);
-      this.logService.addLogMessage(achievement.description, 'STANDARD', 'STORY');
-      // check if gameStateService is injected yet, if not, inject it (circular dependency issues)
-      if (!this.gameStateService) {
-        this.gameStateService = this.injector.get(GameStateService);
-      }
-      this.gameStateService.savetoLocalStorage();
-      this.characterService.toast('Achievement Unlocked: ' + (achievement.displayName ? achievement.displayName : achievement.name));
+      this.services.logService.addLogMessage(achievement.description, 'STANDARD', 'STORY');
+      this.services.gameStateService.savetoLocalStorage();
+      this.services.characterService.toast('Achievement Unlocked: ' + (achievement.displayName ? achievement.displayName : achievement.name));
     }
     achievement.effect();
     achievement.unlocked = true;

--- a/src/app/game-state/character.ts
+++ b/src/app/game-state/character.ts
@@ -573,7 +573,7 @@ export class Character {
       increaseAmount = amount;
     }
     this.attributes[attribute].value += increaseAmount;
-    if (!this.highestAttributes[attribute] || this.highestAttributes[attribute] > this.attributes[attribute].value) {
+    if (!this.highestAttributes[attribute] || this.highestAttributes[attribute] < this.attributes[attribute].value) {
       this.highestAttributes[attribute] = this.attributes[attribute].value;
     }
     return increaseAmount;

--- a/src/app/game-state/followers.service.ts
+++ b/src/app/game-state/followers.service.ts
@@ -1,17 +1,9 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { Injectable, Injector } from '@angular/core';
-import { LogService } from './log.service';
-import { MainLoopService } from './main-loop.service';
-import { CharacterService } from './character.service';
-import { HomeService } from './home.service';
+import { Injectable } from '@angular/core';
 import { FirstNames } from './followerResources';
-import { InventoryService } from './inventory.service';
-import { ItemRepoService } from './item-repo.service';
-import { ReincarnationService } from './reincarnation.service';
-import { BattleService } from './battle.service';
-import { HellService } from './hell.service';
 import { EquipmentPosition } from './character';
 import { CamelToTitlePipe } from '../app.component';
+import { ServicesService } from './services.service';
 
 export type FollowerColor = 'UNMAXED' | 'MAXED';
 
@@ -80,7 +72,6 @@ export class FollowersService {
   totalDied = 0;
   totalDismissed = 0;
   highestLevel = 0;
-  hellService?: HellService;
   unlockedHiddenJobs: string[] = [];
   autoReplaceUnlocked = false;
   petsEnabled = false;
@@ -89,9 +80,9 @@ export class FollowersService {
   jobs: jobsType = {
     "builder": {
       work: () => {
-        this.homeService.nextHomeCostReduction += this.jobs["builder"].totalPower;
-        if (this.homeService.upgrading) {
-          this.homeService.upgradeTick(this.jobs["builder"].totalPower);
+        this.services.homeService.nextHomeCostReduction += this.jobs["builder"].totalPower;
+        if (this.services.homeService.upgrading) {
+          this.services.homeService.upgradeTick(this.jobs["builder"].totalPower);
         }
       },
       description: "Builders reduce the cost of the next home you upgrade to. They can also help you build it faster.",
@@ -99,19 +90,19 @@ export class FollowersService {
     },
     "hunter": {
       work: () => {
-        if (this.hellService?.inHell) {
+        if (this.services.hellService?.inHell) {
           if (this.jobs["hunter"].totalPower > 1000)
-            this.inventoryService.addItem(this.itemRepoService.items['spiritMeat'], Math.floor(this.jobs["hunter"].totalPower / 1000));
+            this.services.inventoryService.addItem(this.services.itemRepoService.items['spiritMeat'], Math.floor(this.jobs["hunter"].totalPower / 1000));
           return;
         }
-        this.inventoryService.addItem(this.itemRepoService.items['meat'], this.jobs["hunter"].totalPower);
+        this.services.inventoryService.addItem(this.services.itemRepoService.items['meat'], this.jobs["hunter"].totalPower);
       },
       description: "Hunters collect meat and help you hunt for hides.",
       totalPower: 0
     },
     "farmer": {
       work: () => {
-        this.homeService.workFields(this.jobs["farmer"].totalPower);
+        this.services.homeService.workFields(this.jobs["farmer"].totalPower);
       },
       description: "Farmers work your fields, helping your crops to grow.",
       totalPower: 0
@@ -119,11 +110,11 @@ export class FollowersService {
     "weaponsmith": {
       work: () => {
         let totalPower = this.jobs["weaponsmith"].totalPower;
-        if (this.hellService?.inHell) {
+        if (this.services.hellService?.inHell) {
           totalPower /= 10;
         }
-        const rightHand = this.characterService.characterState.equipment.rightHand;
-        const leftHand = this.characterService.characterState.equipment.leftHand;
+        const rightHand = this.services.characterService.characterState.equipment.rightHand;
+        const leftHand = this.services.characterService.characterState.equipment.leftHand;
         if (rightHand && rightHand.weaponStats) {
           rightHand.weaponStats.durability += Math.ceil(Math.pow((totalPower / 10), 2) * 100);
           rightHand.weaponStats.baseDamage += Math.ceil(Math.pow(Math.floor(totalPower / 10), 2));
@@ -142,10 +133,10 @@ export class FollowersService {
     "armorer": {
       work: () => {
         let totalPower = this.jobs["armorer"].totalPower;
-        if (this.hellService?.inHell) {
+        if (this.services.hellService?.inHell) {
           totalPower /= 10;
         }
-        const equipment = this.characterService.characterState.equipment; // Too many long names, reduced and referenced
+        const equipment = this.services.characterService.characterState.equipment; // Too many long names, reduced and referenced
         for (const key of ["head", "body", "legs", "feet"] as EquipmentPosition[]) {
           if (equipment[key] && equipment[key]!.armorStats) {
             equipment[key]!.armorStats!.durability += Math.ceil(Math.pow((totalPower / 10), 2) * 50);
@@ -160,10 +151,10 @@ export class FollowersService {
     "brawler": {
       work: () => {
         let totalPower = this.jobs["brawler"].totalPower;
-        if (this.hellService?.inHell) {
+        if (this.services.hellService?.inHell) {
           totalPower /= 10;
         }
-        this.characterService.characterState.increaseAttribute("strength", totalPower);
+        this.services.characterService.characterState.increaseAttribute("strength", totalPower);
       },
       description: "Brawlers will spar with you in wrestling and boxing matches, increasing your strength.",
       totalPower: 0
@@ -171,10 +162,10 @@ export class FollowersService {
     "sprinter": {
       work: () => {
         let totalPower = this.jobs["sprinter"].totalPower;
-        if (this.hellService?.inHell) {
+        if (this.services.hellService?.inHell) {
           totalPower /= 10;
         }
-        this.characterService.characterState.increaseAttribute("speed", totalPower);
+        this.services.characterService.characterState.increaseAttribute("speed", totalPower);
       },
       description: "Sprinters challenge you to footraces and help you increase your speed.",
       totalPower: 0
@@ -182,10 +173,10 @@ export class FollowersService {
     "trainer": {
       work: () => {
         let totalPower = this.jobs["trainer"].totalPower;
-        if (this.hellService?.inHell) {
+        if (this.services.hellService?.inHell) {
           totalPower /= 10;
         }
-        this.characterService.characterState.increaseAttribute("toughness", totalPower);
+        this.services.characterService.characterState.increaseAttribute("toughness", totalPower);
       },
       description: "Trainers make sure you follow their strict fitness and diet rules, increasing your toughness.",
       totalPower: 0
@@ -193,10 +184,10 @@ export class FollowersService {
     "tutor": {
       work: () => {
         let totalPower = this.jobs["tutor"].totalPower;
-        if (this.hellService?.inHell) {
+        if (this.services.hellService?.inHell) {
           totalPower /= 10;
         }
-        this.characterService.characterState.increaseAttribute("intelligence", totalPower);
+        this.services.characterService.characterState.increaseAttribute("intelligence", totalPower);
       },
       description: "Tutors teach you all about the wonders of the universe, increasing your intelligence.",
       totalPower: 0
@@ -204,10 +195,10 @@ export class FollowersService {
     "mediator": {
       work: () => {
         let totalPower = this.jobs["mediator"].totalPower;
-        if (this.hellService?.inHell) {
+        if (this.services.hellService?.inHell) {
           totalPower /= 10;
         }
-        this.characterService.characterState.increaseAttribute("charisma", totalPower);
+        this.services.characterService.characterState.increaseAttribute("charisma", totalPower);
       },
       description: "Mediators teach you how to persuade others, increasing your charisma.",
       totalPower: 0
@@ -215,10 +206,10 @@ export class FollowersService {
     "priest": {
       work: () => {
         let totalPower = this.jobs["priest"].totalPower;
-        if (this.hellService?.inHell) {
+        if (this.services.hellService?.inHell) {
           totalPower /= 10;
         }
-        this.characterService.characterState.increaseAttribute("spirituality", totalPower);
+        this.services.characterService.characterState.increaseAttribute("spirituality", totalPower);
       },
       description: "Priests help you get closer to the divine, increasing your sprituality.",
       totalPower: 0
@@ -226,14 +217,14 @@ export class FollowersService {
     "gemologist": {
       work: () => {
         let gemmerPower = this.jobs["gemologist"].totalPower;
-        if (this.hellService?.inHell) {
+        if (this.services.hellService?.inHell) {
           gemmerPower /= 10;
         }
         gemmerPower = Math.floor(gemmerPower / 50);
         if (gemmerPower > 4) {
           gemmerPower = 4;
         }
-        this.inventoryService.mergeAnySpiritGem(gemmerPower);
+        this.services.inventoryService.mergeAnySpiritGem(gemmerPower);
       },
       description: "Gemologists combine spirit gems into higher grades.",
       totalPower: 0
@@ -241,17 +232,17 @@ export class FollowersService {
     "scout": {
       work: () => {
         let totalPower = this.jobs["scout"].totalPower;
-        if (this.hellService?.inHell) {
+        if (this.services.hellService?.inHell) {
           totalPower /= 10;
         }
-        this.battleService.tickCounter += totalPower;
+        this.services.battleService.tickCounter += totalPower;
       },
       description: "Scouts help you track down and fight monsters faster.",
       totalPower: 0
     },
     "damned": {
       work: () => {
-        this.battleService.tickCounter += this.jobs["damned"].totalPower;
+        this.services.battleService.tickCounter += this.jobs["damned"].totalPower;
       },
       description: "Damned are souls working off karmic debt in hell that hav decided to join you. Having this follower seems to enrage the demons around you.",
       hidden: true,
@@ -276,11 +267,11 @@ export class FollowersService {
         } else if (burnerPower < 1) {
           burnerPower = 1;
         }
-        if (this.characterService.characterState.money < (1e6 / burnerPower)) {
+        if (this.services.characterService.characterState.money < (1e6 / burnerPower)) {
           return;
         }
-        this.characterService.characterState.money -= (1e6 / burnerPower);
-        this.characterService.characterState.hellMoney++;
+        this.services.characterService.characterState.money -= (1e6 / burnerPower);
+        this.services.characterService.characterState.hellMoney++;
       },
       description: "Money Burners dedicate themselves to burning mortal money to produce hell money.",
       hidden: true,
@@ -289,11 +280,11 @@ export class FollowersService {
     "banker": {
       work: () => {
         let totalPower = this.jobs["banker"].totalPower;
-        if (this.hellService?.inHell) {
+        if (this.services.hellService?.inHell) {
           totalPower /= 10;
         }
-        this.characterService.characterState.money += this.characterService.characterState.money * 0.000000273 * totalPower;
-        this.characterService.characterState.hellMoney += this.characterService.characterState.hellMoney * 0.000000273 * totalPower;
+        this.services.characterService.characterState.money += this.services.characterService.characterState.money * 0.000000273 * totalPower;
+        this.services.characterService.characterState.hellMoney += this.services.characterService.characterState.hellMoney * 0.000000273 * totalPower;
       },
       description: "Bankers put your money to use, earning interest on what you have. Surprisingly, this works for hell money too.",
       hidden: true,
@@ -301,7 +292,7 @@ export class FollowersService {
     },
     "snake": {
       work: () => {
-        this.characterService.characterState.increaseAttribute("fireLore", this.jobs["snake"].totalPower);
+        this.services.characterService.characterState.increaseAttribute("fireLore", this.jobs["snake"].totalPower);
       },
       description: "A fiery serpent. Snakes understand fire and can teach you the hidden secrets of the flames.",
       hidden: true,
@@ -310,7 +301,7 @@ export class FollowersService {
     },
     "tiger": {
       work: () => {
-        this.characterService.characterState.increaseAttribute("woodLore", this.jobs["tiger"].totalPower);
+        this.services.characterService.characterState.increaseAttribute("woodLore", this.jobs["tiger"].totalPower);
       },
       description: "Tigers know the secrets of the jungle and can teach you the deepest mysteries of Wood Lore.",
       hidden: true,
@@ -319,7 +310,7 @@ export class FollowersService {
     },
     "ox": {
       work: () => {
-        this.characterService.characterState.increaseAttribute("earthLore", this.jobs["ox"].totalPower);
+        this.services.characterService.characterState.increaseAttribute("earthLore", this.jobs["ox"].totalPower);
       },
       description: "Oxen connect deeply to the earth and can teach you their secret understanding.",
       hidden: true,
@@ -328,7 +319,7 @@ export class FollowersService {
     },
     "monkey": {
       work: () => {
-        this.characterService.characterState.increaseAttribute("metalLore", this.jobs["monkey"].totalPower);
+        this.services.characterService.characterState.increaseAttribute("metalLore", this.jobs["monkey"].totalPower);
       },
       description: "Monkeys know more about metal than the greatest of human blacksmiths.",
       hidden: true,
@@ -337,7 +328,7 @@ export class FollowersService {
     },
     "pig": {
       work: () => {
-        this.characterService.characterState.increaseAttribute("waterLore", this.jobs["pig"].totalPower);
+        this.services.characterService.characterState.increaseAttribute("waterLore", this.jobs["pig"].totalPower);
       },
       description: "Pigs understand the secrets of water and can teach them to you.",
       hidden: true,
@@ -347,27 +338,19 @@ export class FollowersService {
   };
 
   constructor(
-    private injector: Injector,
-    private logService: LogService,
-    private characterService: CharacterService,
-    private homeService: HomeService,
-    private inventoryService: InventoryService,
-    private itemRepoService: ItemRepoService,
-    mainLoopService: MainLoopService,
-    reincarnationService: ReincarnationService,
-    private battleService: BattleService,
+    private services: ServicesService
+  ) {}
 
-  ) {
-    setTimeout(() => this.hellService = this.injector.get(HellService));
-    mainLoopService.tickSubject.subscribe(() => {
+  init(): FollowersService {
+    this.services.mainLoopService.tickSubject.subscribe(() => {
       if (!this.followersUnlocked) {
         return;
       }
-      if (this.characterService.characterState.dead) {
+      if (this.services.characterService.characterState.dead) {
         return;
       }
       this.updateFollowerCap();
-      if (this.characterService.characterState.age % 18250 === 0 && !this.hellService?.inHell) {
+      if (this.services.characterService.characterState.age % 18250 === 0 && !this.services.hellService?.inHell) {
         // another 50xth birthday, you get a follower
         this.generateFollower();
       }
@@ -383,39 +366,40 @@ export class FollowersService {
             if (newFollower) {
               newFollower.power = Math.round(follower.power / 2);
               newFollower.cost = 100 * newFollower.power;
-              this.logService.addLogMessage("Your follower " + follower.name + " passed away from old age but was replaced by their child " + newFollower?.name + ".", "STANDARD", "FOLLOWER");
+              this.services.logService.addLogMessage("Your follower " + follower.name + " passed away from old age but was replaced by their child " + newFollower?.name + ".", "STANDARD", "FOLLOWER");
             }
-            this.logService.addLogMessage("Your follower " + follower.name + " passed away from old age and was not replaced because of your choices in follower jobs.", "STANDARD", "FOLLOWER");
+            this.services.logService.addLogMessage("Your follower " + follower.name + " passed away from old age and was not replaced because of your choices in follower jobs.", "STANDARD", "FOLLOWER");
           } else {
-            this.logService.addLogMessage("Your follower " + follower.name + " passed away from old age.", "INJURY", "FOLLOWER");
+            this.services.logService.addLogMessage("Your follower " + follower.name + " passed away from old age.", "INJURY", "FOLLOWER");
           }
           this.updateFollowerTotalPower();
-        } else if (this.characterService.characterState.money < this.followers[i].cost && !this.hellService?.inHell) {
+        } else if (this.services.characterService.characterState.money < this.followers[i].cost && !this.services.hellService?.inHell) {
           // quit from not being paid
           this.totalDismissed++;
-          this.logService.addLogMessage("You didn't have enough money to suppport your follower " + this.followers[i].name + " so they left your service.", "INJURY", "FOLLOWER");
+          this.services.logService.addLogMessage("You didn't have enough money to suppport your follower " + this.followers[i].name + " so they left your service.", "INJURY", "FOLLOWER");
           this.followers.splice(i, 1);
           this.updateFollowerTotalPower();
-        } else if (!this.hellService?.inHell){
-          this.characterService.characterState.money -= this.followers[i].cost;
+        } else if (!this.services.hellService?.inHell){
+          this.services.characterService.characterState.money -= this.followers[i].cost;
         }
       }
       this.followersWorks();
       this.followersMaxed = this.followers.length < this.followerCap ? this.followersMaxed = 'UNMAXED' : this.followersMaxed = 'MAXED';
     });
 
-    mainLoopService.longTickSubject.subscribe(() => {
+    this.services.mainLoopService.longTickSubject.subscribe(() => {
       this.sortFollowers(this.sortAscending);
     });
 
-    reincarnationService.reincarnateSubject.subscribe(() => {
+    this.services.reincarnationService.reincarnateSubject.subscribe(() => {
       this.reset();
     });
 
+    return this;
   }
 
   updateFollowerCap() {
-    this.followerCap = 1 + (this.homeService.homeValue * 3) + this.characterService.meridianRank() + this.characterService.soulCoreRank() + this.characterService.characterState.bloodlineRank;
+    this.followerCap = 1 + (this.services.homeService.homeValue * 3) + this.services.characterService.meridianRank() + this.services.characterService.soulCoreRank() + this.services.characterService.characterState.bloodlineRank;
     this.followersMaxed = this.followers.length < this.followerCap ? this.followersMaxed = 'UNMAXED' : this.followersMaxed = 'MAXED';
   }
 
@@ -453,8 +437,8 @@ export class FollowersService {
   }
 
   reset() {
-    if (this.characterService.characterState.bloodlineRank >= 7) {
-      this.logService.addLogMessage("Your imperial entourage rejoins you as you set out.", "STANDARD", 'EVENT');
+    if (this.services.characterService.characterState.bloodlineRank >= 7) {
+      this.services.logService.addLogMessage("Your imperial entourage rejoins you as you set out.", "STANDARD", 'EVENT');
     } else {
       this.followers.splice(0, this.followers.length);
       this.followersMaxed = 'UNMAXED';
@@ -534,7 +518,7 @@ export class FollowersService {
           if (this.jobs[key].hidden) {
             continue;
           }
-          let capNumber = (this.maxFollowerByType[key] !== undefined) ? this.maxFollowerByType[key] : 1000;
+          const capNumber = (this.maxFollowerByType[key] !== undefined) ? this.maxFollowerByType[key] : 1000;
           let count = 0;
           for (const follower of this.followers) {
             if (follower.job === key){
@@ -551,12 +535,12 @@ export class FollowersService {
           }
         }
         if (!removedOne){
-          this.logService.addLogMessage("A new follower shows up, but you already have all the followers you want.", "INJURY", "FOLLOWER");
+          this.services.logService.addLogMessage("A new follower shows up, but you already have all the followers you want.", "INJURY", "FOLLOWER");
           this.followersMaxed = 'MAXED'; // Sanity check, true check below.
           return null;
         }
       } else {
-        this.logService.addLogMessage("A new follower shows up, but you already have too many. You are forced to turn them away.", "INJURY", "FOLLOWER");
+        this.services.logService.addLogMessage("A new follower shows up, but you already have too many. You are forced to turn them away.", "INJURY", "FOLLOWER");
         this.followersMaxed = 'MAXED'; // Sanity check, true check below.
         return null;
       }
@@ -567,19 +551,19 @@ export class FollowersService {
       // couldn't find a job that we want
       return null;
     }
-    let capNumber = (this.maxFollowerByType[job] !== undefined) ? this.maxFollowerByType[job] : 1000;
+    const capNumber = (this.maxFollowerByType[job] !== undefined) ? this.maxFollowerByType[job] : 1000;
     if (this.numFollowersOnJob(job) >= capNumber) {
-      this.logService.addLogMessage("A new follower shows up, but they were a " + this.camelToTitle.transform(job) + " and you don't want any more of those.", "STANDARD", "FOLLOWER");
+      this.services.logService.addLogMessage("A new follower shows up, but they were a " + this.camelToTitle.transform(job) + " and you don't want any more of those.", "STANDARD", "FOLLOWER");
       this.totalDismissed++;
       return null;
     }
 
     const lifespanDivider = this.followerLifespanDoubled ? 5 : 10;
-    this.logService.addLogMessage("A new " + this.camelToTitle.transform(job) + " has come to learn at your feet.", "STANDARD", "FOLLOWER");
+    this.services.logService.addLogMessage("A new " + this.camelToTitle.transform(job) + " has come to learn at your feet.", "STANDARD", "FOLLOWER");
     const follower = {
       name: this.generateFollowerName(),
       age: 0,
-      lifespan: Math.min(this.characterService.characterState.lifespan / lifespanDivider, 365000), // cap follower lifespan at 1000 years
+      lifespan: Math.min(this.services.characterService.characterState.lifespan / lifespanDivider, 365000), // cap follower lifespan at 1000 years
       job: job,
       power: 1,
       cost: 100,
@@ -615,7 +599,7 @@ export class FollowersService {
       if (!this.jobs[key].hidden) {
         if ((pet && this.jobs[key].pet) || (!pet && !this.jobs[key].pet)) {
           if (this.onlyWantedFollowers){
-            let capNumber = (this.maxFollowerByType[key] !== undefined) ? this.maxFollowerByType[key] : 1000;
+            const capNumber = (this.maxFollowerByType[key] !== undefined) ? this.maxFollowerByType[key] : 1000;
             if (this.numFollowersOnJob(key) < capNumber){
               possibleJobs.push(key);
             }

--- a/src/app/game-state/hell.service.ts
+++ b/src/app/game-state/hell.service.ts
@@ -620,7 +620,7 @@ export class HellService {
     name: ['Examine Contracts'],
     activityType: ActivityType.ExamineContracts,
     description: ["As if the saw-weilding demons weren't bad enough, this place is a haven for fiendish bureaucrats. Huge piles of paper containing the contracts, covenants, bylaws, stipulations, regulations, and heretofor unspecified legal nonsense for this hell. Maybe if you go through them carefully, you can find a loophole to get yourself an audience with the boss."],
-    consequenceDescription: ['Uses 500,000 stamina because hellish legalize is so incredibly boring.'],
+    consequenceDescription: ['Uses 500,000 stamina because hellish legalese is so incredibly boring.'],
     consequence: [() => {
       this.characterService.characterState.status.stamina.value -= 500000;
       if (this.characterService.characterState.attributes.intelligence.value <= 1e24) {

--- a/src/app/game-state/hell.service.ts
+++ b/src/app/game-state/hell.service.ts
@@ -1,14 +1,7 @@
-import { Injectable, Injector } from '@angular/core';
-import { LogService } from './log.service';
-import { CharacterService } from '../game-state/character.service';
-import { MainLoopService } from './main-loop.service';
-import { ReincarnationService } from './reincarnation.service';
-import { ActivityService } from './activity.service';
-import { BattleService } from './battle.service';
+import { Injectable } from '@angular/core';
 import { Activity, ActivityType } from './activity';
-import { FollowersService } from './followers.service';
-import { Equipment, InventoryService, Item } from './inventory.service';
-import { ItemRepoService } from './item-repo.service';
+import { Equipment, Item } from './inventory.service';
+import { ServicesService } from './services.service';
 
 export enum HellLevel {
   TongueRipping,
@@ -85,579 +78,579 @@ export class HellService {
   timesCrushed = 0;
   contractsExamined = 0;
 
-  burnMoney = {
-    level: 0,
-    name: ['Burn Money'],
-    activityType: ActivityType.BurnMoney,
-    description: ['Burn mortal realm money to receive hell money.'],
-    consequenceDescription: ['Uses a huge pile of mortal money (one million). Gives you 1 hell money.'],
-    consequence: [() => {
-      if (this.characterService.characterState.money < 1e6) {
-        this.logService.addLogMessage("You fail to burn the money that you don't have, and feel pretty dumb for trying.", "STANDARD", "EVENT");
-        return;
-      }
-      this.characterService.characterState.money -= 1e6;
-      this.characterService.characterState.hellMoney++;
-    }],
-    resourceUse: [{
-      stamina: 10
-    }],
-    requirements: [{
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
+  activities: Record<string, Activity> = {};
+  hells: Hell[] = [];
 
-  hellRecruiting = {
-    level: 0,
-    name: ['Recruiting the Damned'],
-    activityType: ActivityType.HellRecruiting,
-    description: ['Look for followers willing to help you.'],
-    consequenceDescription: ['Uses 100 Stamina and 1000 hell money. Gives you a small chance of finding a follower.'],
-    consequence: [() => {
-      if (this.characterService.characterState.attributes.charisma.value < 1e6){
-        this.logService.addLogMessage("You completely fail to catch the attention of any of the damned.", "STANDARD", "EVENT");
-        return;
+  populateActivities(): void {
+    this.activities = {
+      burnMoney: {
+        level: 0,
+        name: ['Burn Money'],
+        activityType: ActivityType.BurnMoney,
+        description: ['Burn mortal realm money to receive hell money.'],
+        consequenceDescription: ['Uses a huge pile of mortal money (one million). Gives you 1 hell money.'],
+        consequence: [() => {
+          if (this.services.characterService.characterState.money < 1e6) {
+            this.services.logService.addLogMessage("You fail to burn the money that you don't have, and feel pretty dumb for trying.", "STANDARD", "EVENT");
+            return;
+          }
+          this.services.characterService.characterState.money -= 1e6;
+          this.services.characterService.characterState.hellMoney++;
+        }],
+        resourceUse: [{
+          stamina: 10
+        }],
+        requirements: [{
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+      hellRecruiting: {
+        level: 0,
+        name: ['Recruiting the Damned'],
+        activityType: ActivityType.HellRecruiting,
+        description: ['Look for followers willing to help you.'],
+        consequenceDescription: ['Uses 100 Stamina and 1000 hell money. Gives you a small chance of finding a follower.'],
+        consequence: [() => {
+          if (this.services.characterService.characterState.attributes.charisma.value < 1e6){
+            this.services.logService.addLogMessage("You completely fail to catch the attention of any of the damned.", "STANDARD", "EVENT");
+            return;
+          }
+          if (this.services.characterService.characterState.hellMoney < 1000) {
+            this.services.logService.addLogMessage("You don't have enough hell money. The damned souls around you team up with the demons to give you a beating.", "INJURY", "EVENT");
+            this.services.characterService.characterState.status.health.value -= this.services.characterService.characterState.status.health.max * 0.2;
+            if (this.services.characterService.characterState.status.health.value <= 0) {
+              this.beaten = true;
+            }
+            return;
+          }
+          this.services.characterService.characterState.status.stamina.value -= 100;
+          this.services.characterService.characterState.hellMoney -= 1000;
+          if (Math.random() < 0.01) {
+            this.services.followerService.generateFollower(false, "damned");
+            this.services.logService.addLogMessage("Your recruiting efforts seem to infuriate the demons here.", "STANDARD", "EVENT");
+          } else {
+            this.services.logService.addLogMessage("You pass around some bribes but fail to find any interested followers today.", "STANDARD", "EVENT");
+          }
+        }],
+        resourceUse: [{
+          stamina: 100
+        }],
+        requirements: [{
+        }],
+        unlocked: false,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      rehabilitation: {
+        level: 0,
+        name: ['Rehabilitate Troublemakers'],
+        activityType: ActivityType.Rehabilitation,
+        description: ['You recognize a bunch of the troublemakers here as people who used to beat and rob you in your past lives. Perhaps you can give them some some friendly rehabilitation. With your fists.'],
+        consequenceDescription: ['Uses 100 Stamina and 10 hell money as bait. Breaks a troublemaker out of their basket and picks a fight with them.'],
+        consequence: [() => {
+          this.services.characterService.characterState.status.stamina.value -= 100;
+          this.services.battleService.addEnemy({
+            name: "Troublemaker",
+            health: 100,
+            maxHealth: 100,
+            accuracy: 0.50,
+            attack: 10,
+            defense: 10,
+            defeatEffect: "respawnDouble",
+            loot: []
+          });
+        }],
+        resourceUse: [{
+          stamina: 100
+        }],
+        requirements: [{
+        }],
+        unlocked: false,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      honorAncestors: {
+        level: 0,
+        name: ['Honor Ancestors'],
+        activityType: ActivityType.HonorAncestors,
+        description: ['You look around and realize that you have many family members and ancestors here. You should probably give them some credit for what they have done for you. And some money.'],
+        consequenceDescription: ['Uses 1 hell money.'],
+        consequence: [() => {
+          if (this.services.characterService.characterState.hellMoney < 1) {
+            this.services.logService.addLogMessage("Your ancestors are not impressed with your lack of financial offerings.", "STANDARD", "EVENT");
+            return;
+          }
+          this.services.characterService.characterState.hellMoney--;
+          this.services.inventoryService.addItem(this.services.itemRepoService.items['tokenOfGratitude']);
+        }],
+        resourceUse: [{
+          stamina: 10
+        }],
+        requirements: [{
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      copperMining:{
+        level: 0,
+        name: ['Copper Mining'],
+        activityType: ActivityType.CopperMining,
+        description: ["The copper pillars here look like they're made of a decent grade of copper. It looks like you have enough slack in your chains to turn and break off some pieces."],
+        consequenceDescription: ['Uses 100,000 stamina and produces one copper bar.'],
+        consequence: [() => {
+          if (this.services.characterService.characterState.attributes.strength.value < 1e24){
+            this.services.logService.addLogMessage("You try to crack into the pillar, but you're not strong enough.", "STANDARD", "EVENT");
+            return;
+          }
+          this.services.characterService.characterState.status.stamina.value -= 100000;
+          this.services.inventoryService.addItem(this.services.itemRepoService.items['copperBar']);
+        }],
+        resourceUse: [{
+          stamina: 100000
+        }],
+        requirements: [{
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      forgeHammer: {
+        level: 0,
+        name: ['Forge Hammer'],
+        activityType: ActivityType.ForgeHammer,
+        description: ["Shape a bar of copper into a hammer using your bare hands. This would be so much easier with an anvil and tools."],
+        consequenceDescription: ['Uses 100,000 stamina and produces the worst hammer in the world.'],
+        consequence: [() => {
+          if (this.services.characterService.characterState.attributes.strength.value < 1e24){
+            this.services.logService.addLogMessage("Your weak muscles flinch at the very thought of trying to mold metal by hand.", "STANDARD", "EVENT");
+            return;
+          }
+          this.services.characterService.characterState.status.stamina.value -= 100000;
+          if (this.services.inventoryService.consume("metal", 1) > 0) {
+            const newHammer: Equipment = {
+              id: 'weapon',
+              name: "Copper Hammer",
+              type: "equipment",
+              slot: "rightHand",
+              value: 1,
+              weaponStats: {
+                baseDamage: 1,
+                material: "metal",
+                durability: 1,
+                baseName: "hammer"
+              },
+              description: 'A crude copper hammer.'
+            };
+            this.services.inventoryService.addItem(newHammer);
+          }
+        }],
+        resourceUse: [{
+          stamina: 100000
+        }],
+        requirements: [{
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      climbMountain: {
+        level: 0,
+        name: ['Climb the Mountain'],
+        activityType: ActivityType.ClimbMountain,
+        description: ["Take another step up the mountain. The path before you seems exceptionally jagged. Maybe you shouldn't have killed so very many little spiders."],
+        consequenceDescription: ['Uses 1000 stamina and works off some of that murderous karma you have built up.'],
+        consequence: [() => {
+          if (this.services.characterService.characterState.attributes.strength.value < 1e24 || this.services.characterService.characterState.attributes.toughness.value < 1e24){
+            this.services.logService.addLogMessage("Your legs give out before you can take a single step up the mountain. Maybe if you were stronger and tougher you could climb.", "STANDARD", "EVENT");
+            return;
+          }
+          this.services.characterService.characterState.status.stamina.value -= 1000;
+          this.mountainSteps++;
+        }],
+        resourceUse: [{
+          stamina: 1000
+        }],
+        requirements: [{
+          strength: 1e24,
+          toughness: 1e24
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      attackClimbers: {
+        level: 0,
+        name: ['Attack Climbers'],
+        activityType: ActivityType.AttackClimbers,
+        description: ["The murderers on this mountain look pretty distracted. It wouldn't be hard to knock them down to the bottom."],
+        consequenceDescription: ['Knock a climber off the mountain.'],
+        consequence: [() => {
+          this.mountainSteps = 0;
+        }],
+        resourceUse: [{
+        }],
+        requirements: [{
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      meltMountain: {
+        level: 0,
+        name: ['Melt the Mountain'],
+        activityType: ActivityType.MeltMountain,
+        description: ["The mountain is far to slippery climb. The only way you're getting to the top is to bring the top down to you."],
+        consequenceDescription: ['Focus your connection to fire and melt that sucker down.'],
+        consequence: [() => {
+          if (this.services.characterService.characterState.attributes.fireLore.value < 1e16){
+            this.services.logService.addLogMessage("Your connection to fire isn't nearly as strong as you thought it was.", "STANDARD", "EVENT");
+            return;
+          }
+    
+          const numberSpawned = Math.log10(this.services.characterService.characterState.attributes.fireLore.value);
+          for (let i = 0; i < numberSpawned; i++) {
+            this.services.battleService.addEnemy({
+              name: "Ice Golem",
+              health: 1e15,
+              maxHealth: 1e15,
+              accuracy: 0.7,
+              attack: 1e6,
+              defense: 1e6,
+              loot: [this.services.itemRepoService.items['iceCore']]
+            });
+          }
+        }],
+        resourceUse: [{
+        }],
+        requirements: [{
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      freezeMountain: {
+        level: 0,
+        name: ['Rock the Lava'],
+        activityType: ActivityType.FreezeMountain,
+        description: ["Swimming in lava is less fun that it seemed like it would be."],
+        consequenceDescription: ['Focus your connection to water and turn that lava back to stone.'],
+        consequence: [() => {
+          if (this.services.characterService.characterState.attributes.waterLore.value < 1e16){
+            this.services.logService.addLogMessage("Your connection to water isn't nearly as strong as you thought it was.", "STANDARD", "EVENT");
+            return;
+          }
+          const numberSpawned = Math.log10(this.services.characterService.characterState.attributes.waterLore.value);
+          for (let i = 0; i < numberSpawned; i++) {
+            this.services.battleService.addEnemy({
+              name: "Lava Golem",
+              health: 1e15,
+              maxHealth: 1e15,
+              accuracy: 0.7,
+              attack: 1e6,
+              defense: 1e6,
+              loot: [this.services.itemRepoService.items['fireCore']]
+            });
+          }
+        }],
+        resourceUse: [{
+        }],
+        requirements: [{
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      healAnimals: {
+        level: 0,
+        name: ['Heal Animals'],
+        activityType: ActivityType.HealAnimals,
+        description: ["You notice that not all the animals here are frenzied killers. Some of them are sick, wounded, and miserable. You resolve to do what good you can here."],
+        consequenceDescription: ['Uses 10,000 mana and 10,000 stamina. Heals an animal.'],
+        consequence: [() => {
+          this.services.characterService.characterState.status.stamina.value -= 10000;
+          this.services.characterService.characterState.status.mana.value -= 10000;
+          this.animalsHealed++;
+        }],
+        resourceUse: [{
+          stamina: 10000,
+          mana: 10000
+        }],
+        requirements: [{
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      liftBoulder: {
+        level: 0,
+        name: ['Lift the Boulder Higher'],
+        activityType: ActivityType.LiftBoulder,
+        description: ["The boulder is heavy, but you are strong. See how high you can lift it."],
+        consequenceDescription: ['Uses 100,000 stamina.'],
+        consequence: [() => {
+          this.services.characterService.characterState.status.stamina.value -= 100000;
+          this.boulderHeight++;
+        }],
+        resourceUse: [{
+          stamina: 10000,
+          mana: 10000
+        }],
+        requirements: [{
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      swim: {
+        level: 0,
+        name: ['Swim Deeper into the Blood'],
+        activityType: ActivityType.Swim,
+        description: ['Swim down further into the crimson depths.'],
+        consequenceDescription: ['Uses 2000 Stamina. Reduce health by 1000.'],
+        consequence: [() => {
+          this.services.characterService.characterState.status.stamina.value -= 2000;
+          this.services.characterService.characterState.status.health.value -= 1000;
+          this.swimDepth++;
+        }],
+        resourceUse: [{
+          stamina: 2000,
+        }],
+        requirements: [{
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      searchForExit: {
+        level: 0,
+        name: ['Search for the Exit'],
+        activityType: ActivityType.SearchForExit,
+        description: ["The lost souls here are searching for a way out, and they can't seem to see the portal you came in on. You could help them search for the exit they're seeking."],
+        consequenceDescription: ['Uses 200,000 Stamina.'],
+        consequence: [() => {
+          this.services.characterService.characterState.status.stamina.value -= 200000;
+          // TODO: tune this
+          if (this.services.characterService.characterState.attributes.intelligence.value <= 1e24) {
+            this.services.logService.addLogMessage("You stumble around completely lost like the rest of the souls here. If only you were smarter.", "STANDARD", "EVENT");
+            return;
+          }
+          const threshold = (Math.log10(this.services.characterService.characterState.attributes.intelligence.value - 1e24) * 0.00001);
+          if (Math.random() < threshold) {
+            this.exitFound = true;
+            if (!this.hells[HellLevel.WrongfulDead].activities.includes(this.activities['teachTheWay'])) {
+              this.hells[HellLevel.WrongfulDead].activities.push(this.activities['teachTheWay']);
+              this.services.activityService.reloadActivities();
+            }
+          }
+        }],
+        resourceUse: [{
+          stamina: 200000,
+        }],
+        requirements: [{
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      teachTheWay: {
+        level: 0,
+        name: ['Teach the Way to the Exit'],
+        activityType: ActivityType.TeachTheWay,
+        description: ["Teach the other damned souls here the way out."],
+        consequenceDescription: ['Uses 200,000 Stamina.'],
+        consequence: [() => {
+          this.services.characterService.characterState.status.stamina.value -= 200000;
+          // TODO: tune this
+          if (this.services.characterService.characterState.attributes.charisma.value <= 1e24) {
+            this.services.logService.addLogMessage("The damned souls completely ignore your attempts at instruction.", "STANDARD", "EVENT");
+            return;
+          }
+          const numberTaught = Math.floor(Math.log10(this.services.characterService.characterState.attributes.charisma.value - 1e24));
+          this.soulsEscaped += numberTaught;
+        }],
+        resourceUse: [{
+          stamina: 200000,
+        }],
+        requirements: [{
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      interrogate: {
+        level: 0,
+        name: ['Interrogate the Damned'],
+        activityType: ActivityType.Interrogate,
+        description: ["Find out where the tomb looters here hid their stolen treasures. You might be able to reverse some of the damage they have done."],
+        consequenceDescription: ['Uses 1000 Stamina.'],
+        consequence: [() => {
+          this.services.characterService.characterState.status.stamina.value -= 1000;
+          if (this.services.characterService.characterState.attributes.charisma.value <= 1e24) {
+            this.services.logService.addLogMessage("The damned here completely ignore you attempts.", "STANDARD", "EVENT");
+            return;
+          }
+          const threshold = (Math.log10(this.services.characterService.characterState.attributes.charisma.value - 1e24) * 0.00001);
+          if (Math.random() < threshold) {
+            this.services.inventoryService.addItem(this.services.itemRepoService.items["treasureMap"]);
+          } else {
+            this.services.logService.addLogMessage("You almost talk a soul into telling you where their treasure is hidden.", "STANDARD", "EVENT");
+          }
+        }],
+        resourceUse: [{
+          stamina: 1000,
+        }],
+        requirements: [{
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      recoverTreasure: {
+        level: 0,
+        name: ['Recover a Treasure'],
+        activityType: ActivityType.RecoverTreasure,
+        description: ["Recover a stolen relic. You'll need all your wits to find it even if you have one the sketchy maps the damned can provide."],
+        consequenceDescription: ['Uses 1000 Stamina.'],
+        consequence: [() => {
+          this.services.characterService.characterState.status.stamina.value -= 1000;
+          if (this.services.characterService.characterState.attributes.intelligence.value <= 1e24) {
+            this.services.logService.addLogMessage("The puzzle your best puzzling but can't figure out how to even start on this relic.", "STANDARD", "EVENT");
+            return;
+          }
+          const threshold = (Math.log10(this.services.characterService.characterState.attributes.intelligence.value - 1e24) * 0.00001);
+          if (Math.random() < threshold) {
+            if (this.services.inventoryService.consume("treasureMap") > 0) {
+              this.services.inventoryService.addItem(this.services.itemRepoService.items["stolenRelic"]);
+            }
+          } else {
+            this.services.logService.addLogMessage("You think you're getting close to figuring out where this relic is. If only you were more clever.", "STANDARD", "EVENT");
+          }
+        }],
+        resourceUse: [{
+          stamina: 1000,
+        }],
+        requirements: [{
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      replaceTreasure: {
+        level: 0,
+        name: ['Replace a Treasure'],
+        activityType: ActivityType.ReplaceTreasure,
+        description: ["Return a stolen relic to the tomb where it came from. You'll need to be quick to avoid the tomb's traps."],
+        consequenceDescription: ['Uses 1000 Stamina.'],
+        consequence: [() => {
+          this.services.characterService.characterState.status.stamina.value -= 1000;
+          if (this.services.characterService.characterState.attributes.speed.value <= 1e24) {
+            this.services.logService.addLogMessage("You are too slow to even attempt replacing a treasure.", "STANDARD", "EVENT");
+            return;
+          }
+          const threshold = (Math.log10(this.services.characterService.characterState.attributes.speed.value - 1e24) * 0.00001);
+          if (Math.random() < threshold) {
+            if (this.services.inventoryService.consume("stolenRelic") > 0) {
+              this.relicsReturned++;
+            }
+          } else {
+            this.services.logService.addLogMessage("You make a good effort to run through the tomb, but you fail. Try harder!", "STANDARD", "EVENT");
+          }
+        }],
+        resourceUse: [{
+          stamina: 1000,
+        }],
+        requirements: [{
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      endureTheMil: {
+        level: 0,
+        name: ['Endure the Mill'],
+        activityType: ActivityType.Endure,
+        description: ["Trapped under the millstone like this, there's not much you can do but endure the punishment. Fortunately, you probably never went out looking for tiny spiders to squash, right?"],
+        consequenceDescription: ['Uses 1000 stamina. Try not to give up. You can do this!'],
+        consequence: [() => {
+          this.services.characterService.characterState.status.stamina.value -= 1000;
+          // TODO: tune this
+          const damage = Math.max(100000 - (this.services.characterService.characterState.attributes.toughness.value / 1e23), 100);
+          this.services.characterService.characterState.status.health.value -= damage;
+          if (this.services.characterService.characterState.status.health.value <= 0) {
+            this.beaten = true;
+          } else {
+            this.timesCrushed++;
+          }
+        }],
+        resourceUse: [{
+          stamina: 1000,
+        }],
+        requirements: [{
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
+      },
+    
+      examineContracts: {
+        level: 0,
+        name: ['Examine Contracts'],
+        activityType: ActivityType.ExamineContracts,
+        description: ["As if the saw-weilding demons weren't bad enough, this place is a haven for fiendish bureaucrats. Huge piles of paper containing the contracts, covenants, bylaws, stipulations, regulations, and heretofor unspecified legal nonsense for this hell. Maybe if you go through them carefully, you can find a loophole to get yourself an audience with the boss."],
+        consequenceDescription: ['Uses 500,000 stamina because hellish legalese is so incredibly boring.'],
+        consequence: [() => {
+          this.services.characterService.characterState.status.stamina.value -= 500000;
+          if (this.services.characterService.characterState.attributes.intelligence.value <= 1e24) {
+            this.services.logService.addLogMessage("You can't even begin to read the complex contracts.", "STANDARD", "EVENT");
+            return;
+          }
+          const threshold = (Math.log10(this.services.characterService.characterState.attributes.intelligence.value - 1e24) * 0.00001);
+          if (Math.random() < threshold) {
+            this.contractsExamined++;
+          } else {
+            this.services.logService.addLogMessage("You very nearly make out the meaning of the scrawled contract.", "STANDARD", "EVENT");
+          }
+        }],
+        resourceUse: [{
+          stamina: 500000,
+        }],
+        requirements: [{
+        }],
+        unlocked: true,
+        discovered: true,
+        skipApprenticeshipLevel: 0
       }
-      if (this.characterService.characterState.hellMoney < 1000) {
-        this.logService.addLogMessage("You don't have enough hell money. The damned souls around you team up with the demons to give you a beating.", "INJURY", "EVENT");
-        this.characterService.characterState.status.health.value -= this.characterService.characterState.status.health.max * 0.2;
-        if (this.characterService.characterState.status.health.value <= 0) {
-          this.beaten = true;
-        }
-        return;
-      }
-      this.characterService.characterState.status.stamina.value -= 100;
-      this.characterService.characterState.hellMoney -= 1000;
-      if (Math.random() < 0.01) {
-        this.followerService.generateFollower(false, "damned");
-        this.logService.addLogMessage("Your recruiting efforts seem to infuriate the demons here.", "STANDARD", "EVENT");
-      } else {
-        this.logService.addLogMessage("You pass around some bribes but fail to find any interested followers today.", "STANDARD", "EVENT");
-      }
-    }],
-    resourceUse: [{
-      stamina: 100
-    }],
-    requirements: [{
-    }],
-    unlocked: false,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  rehabilitation = {
-    level: 0,
-    name: ['Rehabilitate Troublemakers'],
-    activityType: ActivityType.Rehabilitation,
-    description: ['You recognize a bunch of the troublemakers here as people who used to beat and rob you in your past lives. Perhaps you can give them some some friendly rehabilitation. With your fists.'],
-    consequenceDescription: ['Uses 100 Stamina and 10 hell money as bait. Breaks a troublemaker out of their basket and picks a fight with them.'],
-    consequence: [() => {
-      this.characterService.characterState.status.stamina.value -= 100;
-      this.battleService.addEnemy({
-        name: "Troublemaker",
-        health: 100,
-        maxHealth: 100,
-        accuracy: 0.50,
-        attack: 10,
-        defense: 10,
-        defeatEffect: "respawnDouble",
-        loot: []
-      });
-    }],
-    resourceUse: [{
-      stamina: 100
-    }],
-    requirements: [{
-    }],
-    unlocked: false,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  honorAncestors = {
-    level: 0,
-    name: ['Honor Ancestors'],
-    activityType: ActivityType.HonorAncestors,
-    description: ['You look around and realize that you have many family members and ancestors here. You should probably give them some credit for what they have done for you. And some money.'],
-    consequenceDescription: ['Uses 1 hell money.'],
-    consequence: [() => {
-      if (this.characterService.characterState.hellMoney < 1) {
-        this.logService.addLogMessage("Your ancestors are not impressed with your lack of financial offerings.", "STANDARD", "EVENT");
-        return;
-      }
-      this.characterService.characterState.hellMoney--;
-      this.inventoryService.addItem(this.itemRepoService.items['tokenOfGratitude']);
-    }],
-    resourceUse: [{
-      stamina: 10
-    }],
-    requirements: [{
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  copperMining = {
-    level: 0,
-    name: ['Copper Mining'],
-    activityType: ActivityType.CopperMining,
-    description: ["The copper pillars here look like they're made of a decent grade of copper. It looks like you have enough slack in your chains to turn and break off some pieces."],
-    consequenceDescription: ['Uses 100,000 stamina and produces one copper bar.'],
-    consequence: [() => {
-      if (this.characterService.characterState.attributes.strength.value < 1e24){
-        this.logService.addLogMessage("You try to crack into the pillar, but you're not strong enough.", "STANDARD", "EVENT");
-        return;
-      }
-      this.characterService.characterState.status.stamina.value -= 100000;
-      this.inventoryService.addItem(this.itemRepoService.items['copperBar']);
-    }],
-    resourceUse: [{
-      stamina: 100000
-    }],
-    requirements: [{
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  forgeHammer = {
-    level: 0,
-    name: ['Forge Hammer'],
-    activityType: ActivityType.ForgeHammer,
-    description: ["Shape a bar of copper into a hammer using your bare hands. This would be so much easier with an anvil and tools."],
-    consequenceDescription: ['Uses 100,000 stamina and produces the worst hammer in the world.'],
-    consequence: [() => {
-      if (this.characterService.characterState.attributes.strength.value < 1e24){
-        this.logService.addLogMessage("Your weak muscles flinch at the very thought of trying to mold metal by hand.", "STANDARD", "EVENT");
-        return;
-      }
-      this.characterService.characterState.status.stamina.value -= 100000;
-      if (this.inventoryService.consume("metal", 1) > 0) {
-        const newHammer: Equipment = {
-          id: 'weapon',
-          name: "Copper Hammer",
-          type: "equipment",
-          slot: "rightHand",
-          value: 1,
-          weaponStats: {
-            baseDamage: 1,
-            material: "metal",
-            durability: 1,
-            baseName: "hammer"
-          },
-          description: 'A crude copper hammer.'
-        };
-        this.inventoryService.addItem(newHammer);
-      }
-    }],
-    resourceUse: [{
-      stamina: 100000
-    }],
-    requirements: [{
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  climbMountain = {
-    level: 0,
-    name: ['Climb the Mountain'],
-    activityType: ActivityType.ClimbMountain,
-    description: ["Take another step up the mountain. The path before you seems exceptionally jagged. Maybe you shouldn't have killed so very many little spiders."],
-    consequenceDescription: ['Uses 1000 stamina and works off some of that murderous karma you have built up.'],
-    consequence: [() => {
-      if (this.characterService.characterState.attributes.strength.value < 1e24 || this.characterService.characterState.attributes.toughness.value < 1e24){
-        this.logService.addLogMessage("Your legs give out before you can take a single step up the mountain. Maybe if you were stronger and tougher you could climb.", "STANDARD", "EVENT");
-        return;
-      }
-      this.characterService.characterState.status.stamina.value -= 1000;
-      this.mountainSteps++;
-    }],
-    resourceUse: [{
-      stamina: 1000
-    }],
-    requirements: [{
-      strength: 1e24,
-      toughness: 1e24
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  attackClimbers = {
-    level: 0,
-    name: ['Attack Climbers'],
-    activityType: ActivityType.AttackClimbers,
-    description: ["The murderers on this mountain look pretty distracted. It wouldn't be hard to knock them down to the bottom."],
-    consequenceDescription: ['Knock a climber off the mountain.'],
-    consequence: [() => {
-      this.mountainSteps = 0;
-    }],
-    resourceUse: [{
-    }],
-    requirements: [{
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  meltMountain = {
-    level: 0,
-    name: ['Melt the Mountain'],
-    activityType: ActivityType.MeltMountain,
-    description: ["The mountain is far to slippery climb. The only way you're getting to the top is to bring the top down to you."],
-    consequenceDescription: ['Focus your connection to fire and melt that sucker down.'],
-    consequence: [() => {
-      if (this.characterService.characterState.attributes.fireLore.value < 1e16){
-        this.logService.addLogMessage("Your connection to fire isn't nearly as strong as you thought it was.", "STANDARD", "EVENT");
-        return;
-      }
-
-      const numberSpawned = Math.log10(this.characterService.characterState.attributes.fireLore.value);
-      for (let i = 0; i < numberSpawned; i++) {
-        this.battleService.addEnemy({
-          name: "Ice Golem",
-          health: 1e15,
-          maxHealth: 1e15,
-          accuracy: 0.7,
-          attack: 1e6,
-          defense: 1e6,
-          loot: [this.itemRepoService.items['iceCore']]
-        });
-      }
-    }],
-    resourceUse: [{
-    }],
-    requirements: [{
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  freezeMountain = {
-    level: 0,
-    name: ['Rock the Lava'],
-    activityType: ActivityType.FreezeMountain,
-    description: ["Swimming in lava is less fun that it seemed like it would be."],
-    consequenceDescription: ['Focus your connection to water and turn that lava back to stone.'],
-    consequence: [() => {
-      if (this.characterService.characterState.attributes.waterLore.value < 1e16){
-        this.logService.addLogMessage("Your connection to water isn't nearly as strong as you thought it was.", "STANDARD", "EVENT");
-        return;
-      }
-      const numberSpawned = Math.log10(this.characterService.characterState.attributes.waterLore.value);
-      for (let i = 0; i < numberSpawned; i++) {
-        this.battleService.addEnemy({
-          name: "Lava Golem",
-          health: 1e15,
-          maxHealth: 1e15,
-          accuracy: 0.7,
-          attack: 1e6,
-          defense: 1e6,
-          loot: [this.itemRepoService.items['fireCore']]
-        });
-      }
-    }],
-    resourceUse: [{
-    }],
-    requirements: [{
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  healAnimals = {
-    level: 0,
-    name: ['Heal Animals'],
-    activityType: ActivityType.HealAnimals,
-    description: ["You notice that not all the animals here are frenzied killers. Some of them are sick, wounded, and miserable. You resolve to do what good you can here."],
-    consequenceDescription: ['Uses 10,000 mana and 10,000 stamina. Heals an animal.'],
-    consequence: [() => {
-      this.characterService.characterState.status.stamina.value -= 10000;
-      this.characterService.characterState.status.mana.value -= 10000;
-      this.animalsHealed++;
-    }],
-    resourceUse: [{
-      stamina: 10000,
-      mana: 10000
-    }],
-    requirements: [{
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  liftBoulder = {
-    level: 0,
-    name: ['Lift the Boulder Higher'],
-    activityType: ActivityType.LiftBoulder,
-    description: ["The boulder is heavy, but you are strong. See how high you can lift it."],
-    consequenceDescription: ['Uses 100,000 stamina.'],
-    consequence: [() => {
-      this.characterService.characterState.status.stamina.value -= 100000;
-      this.boulderHeight++;
-    }],
-    resourceUse: [{
-      stamina: 10000,
-      mana: 10000
-    }],
-    requirements: [{
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  swim = {
-    level: 0,
-    name: ['Swim Deeper into the Blood'],
-    activityType: ActivityType.Swim,
-    description: ['Swim down further into the crimson depths.'],
-    consequenceDescription: ['Uses 2000 Stamina. Reduce health by 1000.'],
-    consequence: [() => {
-      this.characterService.characterState.status.stamina.value -= 2000;
-      this.characterService.characterState.status.health.value -= 1000;
-      this.swimDepth++;
-    }],
-    resourceUse: [{
-      stamina: 2000,
-    }],
-    requirements: [{
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  searchForExit = {
-    level: 0,
-    name: ['Search for the Exit'],
-    activityType: ActivityType.SearchForExit,
-    description: ["The lost souls here are searching for a way out, and they can't seem to see the portal you came in on. You could help them search for the exit they're seeking."],
-    consequenceDescription: ['Uses 200,000 Stamina.'],
-    consequence: [() => {
-      this.characterService.characterState.status.stamina.value -= 200000;
-      // TODO: tune this
-      if (this.characterService.characterState.attributes.intelligence.value <= 1e24) {
-        this.logService.addLogMessage("You stumble around completely lost like the rest of the souls here. If only you were smarter.", "STANDARD", "EVENT");
-        return;
-      }
-      const threshold = (Math.log10(this.characterService.characterState.attributes.intelligence.value - 1e24) * 0.00001);
-      if (Math.random() < threshold) {
-        this.exitFound = true;
-        if (!this.hells[HellLevel.WrongfulDead].activities.includes(this.teachTheWay)) {
-          this.hells[HellLevel.WrongfulDead].activities.push(this.teachTheWay);
-          this.activityService.reloadActivities();
-        }
-      }
-    }],
-    resourceUse: [{
-      stamina: 200000,
-    }],
-    requirements: [{
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  teachTheWay = {
-    level: 0,
-    name: ['Teach the Way to the Exit'],
-    activityType: ActivityType.TeachTheWay,
-    description: ["Teach the other damned souls here the way out."],
-    consequenceDescription: ['Uses 200,000 Stamina.'],
-    consequence: [() => {
-      this.characterService.characterState.status.stamina.value -= 200000;
-      // TODO: tune this
-      if (this.characterService.characterState.attributes.charisma.value <= 1e24) {
-        this.logService.addLogMessage("The damned souls completely ignore your attempts at instruction.", "STANDARD", "EVENT");
-        return;
-      }
-      const numberTaught = Math.floor(Math.log10(this.characterService.characterState.attributes.charisma.value - 1e24));
-      this.soulsEscaped += numberTaught;
-    }],
-    resourceUse: [{
-      stamina: 200000,
-    }],
-    requirements: [{
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  interrogate = {
-    level: 0,
-    name: ['Interrogate the Damned'],
-    activityType: ActivityType.Interrogate,
-    description: ["Find out where the tomb looters here hid their stolen treasures. You might be able to reverse some of the damage they have done."],
-    consequenceDescription: ['Uses 1000 Stamina.'],
-    consequence: [() => {
-      this.characterService.characterState.status.stamina.value -= 1000;
-      if (this.characterService.characterState.attributes.charisma.value <= 1e24) {
-        this.logService.addLogMessage("The damned here completely ignore you attempts.", "STANDARD", "EVENT");
-        return;
-      }
-      const threshold = (Math.log10(this.characterService.characterState.attributes.charisma.value - 1e24) * 0.00001);
-      if (Math.random() < threshold) {
-        this.inventoryService.addItem(this.itemRepoService.items["treasureMap"]);
-      } else {
-        this.logService.addLogMessage("You almost talk a soul into telling you where their treasure is hidden.", "STANDARD", "EVENT");
-      }
-    }],
-    resourceUse: [{
-      stamina: 1000,
-    }],
-    requirements: [{
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  recoverTreasure = {
-    level: 0,
-    name: ['Recover a Treasure'],
-    activityType: ActivityType.RecoverTreasure,
-    description: ["Recover a stolen relic. You'll need all your wits to find it even if you have one the sketchy maps the damned can provide."],
-    consequenceDescription: ['Uses 1000 Stamina.'],
-    consequence: [() => {
-      this.characterService.characterState.status.stamina.value -= 1000;
-      if (this.characterService.characterState.attributes.intelligence.value <= 1e24) {
-        this.logService.addLogMessage("The puzzle your best puzzling but can't figure out how to even start on this relic.", "STANDARD", "EVENT");
-        return;
-      }
-      const threshold = (Math.log10(this.characterService.characterState.attributes.intelligence.value - 1e24) * 0.00001);
-      if (Math.random() < threshold) {
-        if (this.inventoryService.consume("treasureMap") > 0) {
-          this.inventoryService.addItem(this.itemRepoService.items["stolenRelic"]);
-        }
-      } else {
-        this.logService.addLogMessage("You think you're getting close to figuring out where this relic is. If only you were more clever.", "STANDARD", "EVENT");
-      }
-    }],
-    resourceUse: [{
-      stamina: 1000,
-    }],
-    requirements: [{
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  replaceTreasure = {
-    level: 0,
-    name: ['Replace a Treasure'],
-    activityType: ActivityType.ReplaceTreasure,
-    description: ["Return a stolen relic to the tomb where it came from. You'll need to be quick to avoid the tomb's traps."],
-    consequenceDescription: ['Uses 1000 Stamina.'],
-    consequence: [() => {
-      this.characterService.characterState.status.stamina.value -= 1000;
-      if (this.characterService.characterState.attributes.speed.value <= 1e24) {
-        this.logService.addLogMessage("You are too slow to even attempt replacing a treasure.", "STANDARD", "EVENT");
-        return;
-      }
-      const threshold = (Math.log10(this.characterService.characterState.attributes.speed.value - 1e24) * 0.00001);
-      if (Math.random() < threshold) {
-        if (this.inventoryService.consume("stolenRelic") > 0) {
-          this.relicsReturned++;
-        }
-      } else {
-        this.logService.addLogMessage("You make a good effort to run through the tomb, but you fail. Try harder!", "STANDARD", "EVENT");
-      }
-    }],
-    resourceUse: [{
-      stamina: 1000,
-    }],
-    requirements: [{
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  endureTheMill = {
-    level: 0,
-    name: ['Endure the Mill'],
-    activityType: ActivityType.Endure,
-    description: ["Trapped under the millstone like this, there's not much you can do but endure the punishment. Fortunately, you probably never went out looking for tiny spiders to squash, right?"],
-    consequenceDescription: ['Uses 1000 stamina. Try not to give up. You can do this!'],
-    consequence: [() => {
-      this.characterService.characterState.status.stamina.value -= 1000;
-      // TODO: tune this
-      const damage = Math.max(100000 - (this.characterService.characterState.attributes.toughness.value / 1e23), 100);
-      this.characterService.characterState.status.health.value -= damage;
-      if (this.characterService.characterState.status.health.value <= 0) {
-        this.beaten = true;
-      } else {
-        this.timesCrushed++;
-      }
-    }],
-    resourceUse: [{
-      stamina: 1000,
-    }],
-    requirements: [{
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
-  }
-
-  examineContracts = {
-    level: 0,
-    name: ['Examine Contracts'],
-    activityType: ActivityType.ExamineContracts,
-    description: ["As if the saw-weilding demons weren't bad enough, this place is a haven for fiendish bureaucrats. Huge piles of paper containing the contracts, covenants, bylaws, stipulations, regulations, and heretofor unspecified legal nonsense for this hell. Maybe if you go through them carefully, you can find a loophole to get yourself an audience with the boss."],
-    consequenceDescription: ['Uses 500,000 stamina because hellish legalese is so incredibly boring.'],
-    consequence: [() => {
-      this.characterService.characterState.status.stamina.value -= 500000;
-      if (this.characterService.characterState.attributes.intelligence.value <= 1e24) {
-        this.logService.addLogMessage("You can't even begin to read the complex contracts.", "STANDARD", "EVENT");
-        return;
-      }
-      const threshold = (Math.log10(this.characterService.characterState.attributes.intelligence.value - 1e24) * 0.00001);
-      if (Math.random() < threshold) {
-        this.contractsExamined++;
-      } else {
-        this.logService.addLogMessage("You very nearly make out the meaning of the scrawled contract.", "STANDARD", "EVENT");
-      }
-    }],
-    resourceUse: [{
-      stamina: 500000,
-    }],
-    requirements: [{
-    }],
-    unlocked: true,
-    discovered: true,
-    skipApprenticeshipLevel: 0
+    };
   }
 
   constructor(
-    private injector: Injector,
-    private logService: LogService,
-    private characterService: CharacterService,
-    mainLoopService: MainLoopService,
-    reincarnationService: ReincarnationService,
-    private activityService: ActivityService,
-    private followerService: FollowersService,
-    private battleService: BattleService,
-    private inventoryService: InventoryService,
-    private itemRepoService: ItemRepoService
-  ) {
+    private services: ServicesService
+  ) {}
 
-    mainLoopService.tickSubject.subscribe(() => {
+  init(): HellService {
+    this.populateActivities();
+    this.populateHells();
+    this.services.mainLoopService.tickSubject.subscribe(() => {
       if (this.currentHell < 0) {
         // not currently in a hell, bail out
         return;
@@ -668,14 +661,14 @@ export class HellService {
       }
       if (this.beaten) {
         this.beaten = false;
-        this.logService.addLogMessage("You fall to your knees, unable to bear more damage. You crawl back through this hell's gate to get a moment of respite at the gates of Lord Yama's realm.", "INJURY", "EVENT");
-        this.battleService.enemies = [];
-        this.battleService.currentEnemy = null;
+        this.services.logService.addLogMessage("You fall to your knees, unable to bear more damage. You crawl back through this hell's gate to get a moment of respite at the gates of Lord Yama's realm.", "INJURY", "EVENT");
+        this.services.battleService.enemies = [];
+        this.services.battleService.currentEnemy = null;
         if (hell.exitEffect) {
           hell.exitEffect();
         }
         this.currentHell = -1;
-        this.activityService.reloadActivities();
+        this.services.activityService.reloadActivities();
       }
       if (!this.completedHellTasks.includes(this.currentHell) && hell.successCheck()) {
         hell.completeEffect();
@@ -683,9 +676,11 @@ export class HellService {
       }
     });
 
-    reincarnationService.reincarnateSubject.subscribe(() => {
+    this.services.reincarnationService.reincarnateSubject.subscribe(() => {
       this.reset();
     });
+
+    return this;
   }
 
   reset() {
@@ -699,7 +694,7 @@ export class HellService {
       }
       this.inHell = false;
       this.currentHell = -1;
-      this.activityService.reloadActivities();
+      this.services.activityService.reloadActivities();
     }
   }
 
@@ -712,71 +707,71 @@ export class HellService {
     if (this.currentHell === HellLevel.TongueRipping) {
       // monsters get stronger the more you've recruited/trained
       // tinker with stats/growth
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Tongue Ripper",
         health: 1e20 + (1e19 * hellProgress),
         maxHealth: 1e20 + (1e19 * hellProgress),
         accuracy: 0.50,
         attack: 1e6 + (1e4 * hellProgress),
         defense: 1e8 + (1e7 * hellProgress),
-        loot: [this.inventoryService.generateSpiritGem(Math.floor(Math.log2(hellProgress + 2)), "corruption")]
+        loot: [this.services.inventoryService.generateSpiritGem(Math.floor(Math.log2(hellProgress + 2)), "corruption")]
       });
     } else if (this.currentHell === HellLevel.Scissors) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Scissors Demon",
         health: 1e15 + (1e14 * hellProgress),
         maxHealth: 1e15 + (1e14 * hellProgress),
         accuracy: 0.50,
         attack: 1e6 + (1e4 * hellProgress),
         defense: 1e8 + (1e7 * hellProgress),
-        loot: [this.inventoryService.generateSpiritGem(Math.floor(Math.log2(hellProgress + 2)), "corruption"), this.itemRepoService.items['fingers']]
+        loot: [this.services.inventoryService.generateSpiritGem(Math.floor(Math.log2(hellProgress + 2)), "corruption"), this.services.itemRepoService.items['fingers']]
       });
     } else if (this.currentHell === HellLevel.TreesOfKnives) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Hungry Crow",
         health: 1e6,
         maxHealth: 1e6,
         accuracy: 1,
         attack: 1e6,
         defense: 1e6,
-        loot: [this.inventoryService.generateSpiritGem(25, "corruption")]
+        loot: [this.services.inventoryService.generateSpiritGem(25, "corruption")]
       });
     } else if (this.currentHell === HellLevel.Mirrors) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Your Reflection",
-        health: this.characterService.characterState.status.health.value,
-        maxHealth: this.characterService.characterState.status.health.value,
-        accuracy: this.characterService.characterState.accuracy,
-        attack: this.characterService.characterState.attackPower,
-        defense: this.characterService.characterState.defense,
-        loot: [this.itemRepoService.items['mirrorShard']]
+        health: this.services.characterService.characterState.status.health.value,
+        maxHealth: this.services.characterService.characterState.status.health.value,
+        accuracy: this.services.characterService.characterState.accuracy,
+        attack: this.services.characterService.characterState.attackPower,
+        defense: this.services.characterService.characterState.defense,
+        loot: [this.services.itemRepoService.items['mirrorShard']]
       });
     } else if (this.currentHell === HellLevel.CauldronsOfOil) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Oiled Demon",
         health: 1e20 + (1e19 * hellProgress),
         maxHealth: 1e20 + (1e19 * hellProgress),
         accuracy: 1,
         attack: 1e6,
         defense: 1e8,
-        loot: [this.inventoryService.generateSpiritGem(25, "corruption")]
+        loot: [this.services.inventoryService.generateSpiritGem(25, "corruption")]
       });
     } else if (this.currentHell === HellLevel.CattlePit) {
       if (this.animalsHealed <= 1000000) {
         for (let i = 0; i < 10; i++) {
-          this.battleService.addEnemy({
+          this.services.battleService.addEnemy({
             name: "Demonic Cow",
             health: 1e20 + (1e19 * hellProgress),
             maxHealth: 1e20 + (1e19 * hellProgress),
             accuracy: 1,
             attack: 1e6,
             defense: 1e8,
-            loot: [this.inventoryService.generateSpiritGem(25, "corruption")]
+            loot: [this.services.inventoryService.generateSpiritGem(25, "corruption")]
           });
         }
       }
     } else if (this.currentHell === HellLevel.MortarsAndPestles) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Force Feeder",
         health: 1e6,
         maxHealth: 1e6,
@@ -785,27 +780,27 @@ export class HellService {
         defense: 1e6,
         attackEffect: "feeder",
         hitTracker: 0,
-        loot: [this.inventoryService.generateSpiritGem(25, "corruption")]
+        loot: [this.services.inventoryService.generateSpiritGem(25, "corruption")]
       });
     } else if (this.currentHell === HellLevel.Dismemberment) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Axe Demon",
         health: 1e20 + (1e19 * hellProgress),
         maxHealth: 1e20 + (1e19 * hellProgress),
         accuracy: 1,
         attack: 1e6,
         defense: 1e8,
-        loot: [this.inventoryService.generateSpiritGem(25, "corruption")]
+        loot: [this.services.inventoryService.generateSpiritGem(25, "corruption")]
       });
     } else if (this.currentHell === HellLevel.Saws) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Saw Demon",
         health: 1e20 + (1e19 * hellProgress),
         maxHealth: 1e20 + (1e19 * hellProgress),
         accuracy: 1,
         attack: 1e6,
         defense: 1e8,
-        loot: [this.inventoryService.generateSpiritGem(25, "corruption")]
+        loot: [this.services.inventoryService.generateSpiritGem(25, "corruption")]
       });
     }
   }
@@ -813,184 +808,184 @@ export class HellService {
   fightHellBoss() {
       // TODO: tune stats
       if (this.currentHell === HellLevel.TongueRipping) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Gorbolash the Gossip Gasher",
         health: 1e30,
         maxHealth: 1e30,
         accuracy: 0.8,
         attack: 1e10,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownTongueRippers']]
+        loot: [this.services.itemRepoService.items['hellCrownTongueRippers']]
       });
     } else if (this.currentHell === HellLevel.Scissors) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Malgorath the Marriage Masher",
         health: 1e27,
         maxHealth: 1e27,
         accuracy: 0.8,
         attack: 1e11,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownScissors']]
+        loot: [this.services.itemRepoService.items['hellCrownScissors']]
       });
     } else if (this.currentHell === HellLevel.TreesOfKnives) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Flamgolus the Family Flayer",
         health: 1e30,
         maxHealth: 1e30,
         accuracy: 0.8,
         attack: 1e10,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownTreesOfKnives']]
+        loot: [this.services.itemRepoService.items['hellCrownTreesOfKnives']]
       });
     } else if (this.currentHell === HellLevel.Mirrors) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Myorshuggath the Mirror Master",
         health: 1e30,
         maxHealth: 1e30,
         accuracy: 0.8,
         attack: 1e10,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownMirrors']]
+        loot: [this.services.itemRepoService.items['hellCrownMirrors']]
       });
     } else if (this.currentHell === HellLevel.Steamers) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Stactolus the Steamer",
         health: 1e27,
         maxHealth: 1e27,
         accuracy: 0.8,
         attack: 1e10,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownSteamers']]
+        loot: [this.services.itemRepoService.items['hellCrownSteamers']]
       });
     } else if (this.currentHell === HellLevel.CopperPillars) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Ignificor the Forever Burning",
         health: 1e30,
         maxHealth: 1e30,
         accuracy: 0.8,
         attack: 1e10,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownPillars']]
+        loot: [this.services.itemRepoService.items['hellCrownPillars']]
       });
     } else if (this.currentHell === HellLevel.MountainOfKnives) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Malignus the Murderer Muncher",
         health: 1e30,
         maxHealth: 1e30,
         accuracy: 0.8,
         attack: 1e10,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownMountainOfKnives']]
+        loot: [this.services.itemRepoService.items['hellCrownMountainOfKnives']]
       });
     } else if (this.currentHell === HellLevel.MountainOfIce) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "The Cheat",
         health: 1e30,
         maxHealth: 1e30,
         accuracy: 0.8,
         attack: 1e10,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownMountainOfIce']]
+        loot: [this.services.itemRepoService.items['hellCrownMountainOfIce']]
       });
     } else if (this.currentHell === HellLevel.CauldronsOfOil) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Nestor the Molestor",
         health: 1e30,
         maxHealth: 1e30,
         accuracy: 0.8,
         attack: 1e10,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownCauldronsOfOil']]
+        loot: [this.services.itemRepoService.items['hellCrownCauldronsOfOil']]
       });
     } else if (this.currentHell === HellLevel.CattlePit) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "The Cow Emperor",
         health: 1e30,
         maxHealth: 1e30,
         accuracy: 0.8,
         attack: 1e10,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownCattlePit']]
+        loot: [this.services.itemRepoService.items['hellCrownCattlePit']]
       });
     } else if (this.currentHell === HellLevel.CrushingBoulder) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "The Crusher",
         health: 1e30,
         maxHealth: 1e30,
         accuracy: 0.8,
         attack: 1e10,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownCrushingBoulder']]
+        loot: [this.services.itemRepoService.items['hellCrownCrushingBoulder']]
       });
     } else if (this.currentHell === HellLevel.MortarsAndPestles) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Glorbulskath the Gluttonous",
         health: 1e30,
         maxHealth: 1e30,
         accuracy: 0.8,
         attack: 1e10,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownMortarsAndPestles']]
+        loot: [this.services.itemRepoService.items['hellCrownMortarsAndPestles']]
       });
     } else if (this.currentHell === HellLevel.BloodPool) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Gnarlyathor the Ever-Bleeding",
         health: 1e30,
         maxHealth: 1e30,
         accuracy: 0.8,
         attack: 1e10,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownBloodPool']]
+        loot: [this.services.itemRepoService.items['hellCrownBloodPool']]
       });
     } else if (this.currentHell === HellLevel.WrongfulDead) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Azoth-Raketh the Storm Master",
         health: 1e30,
         maxHealth: 1e30,
         accuracy: 0.8,
         attack: 1e10,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownWrongfulDead']]
+        loot: [this.services.itemRepoService.items['hellCrownWrongfulDead']]
       });
     } else if (this.currentHell === HellLevel.Dismemberment) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Druskall the Dismemberer",
         health: 1e30,
         maxHealth: 1e30,
         accuracy: 0.8,
         attack: 1e10,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownDismemberment']]
+        loot: [this.services.itemRepoService.items['hellCrownDismemberment']]
       });
     } else if (this.currentHell === HellLevel.MountainOfFire) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Magmar the Lava King",
         health: 1e30,
         maxHealth: 1e30,
         accuracy: 0.8,
         attack: 1e10,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownFireMountain']]
+        loot: [this.services.itemRepoService.items['hellCrownFireMountain']]
       });
     } else if (this.currentHell === HellLevel.Mills) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Grimstone The Human Grinder",
         health: 1e30,
         maxHealth: 1e30,
         accuracy: 0.8,
         attack: 1e10,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownMills']]
+        loot: [this.services.itemRepoService.items['hellCrownMills']]
       });
     } else if (this.currentHell === HellLevel.Saws) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Crognaslark the Corrupter",
         health: 1e30,
         maxHealth: 1e30,
         accuracy: 0.8,
         attack: 1e10,
         defense: 1e12,
-        loot: [this.itemRepoService.items['hellCrownSaws']]
+        loot: [this.services.itemRepoService.items['hellCrownSaws']]
       });
     }
   }
@@ -1029,19 +1024,19 @@ export class HellService {
     this.relicsReturned = properties.relicsReturned || 0;
     this.timesCrushed = properties.timesCrushed || 0;
     this.contractsExamined = properties.contractsExamined || 0;
-    this.activityService.reloadActivities();
+    this.services.activityService.reloadActivities();
   }
 
   getActivityList() {
     const newList: Activity[] = [];
     if (this.currentHell === -1) {
       // between hells now, choose which one to enter
-      this.activityService.activityHeader = "Choose your Hell";
-      this.activityService.activityHeaderDescription = "The heavens have cast you down to the depths of hell. You'll need to defeat every level to escape.";
+      this.services.activityService.activityHeader = "Choose your Hell";
+      this.services.activityService.activityHeaderDescription = "The heavens have cast you down to the depths of hell. You'll need to defeat every level to escape.";
       this.setEnterHellsArray(newList);
     } else {
-      this.activityService.activityHeader = this.hells[this.currentHell].name;
-      this.activityService.activityHeaderDescription = this.hells[this.currentHell].description;
+      this.services.activityService.activityHeader = this.hells[this.currentHell].name;
+      this.services.activityService.activityHeaderDescription = this.hells[this.currentHell].description;
       const hell = this.hells[this.currentHell];
       for (const activity of hell.activities) {
         if (activity) {
@@ -1068,14 +1063,14 @@ export class HellService {
       description: ["Return to the gates of Lord Yama's realm."],
       consequenceDescription: [""],
       consequence: [() => {
-        this.battleService.enemies = [];
-        this.battleService.currentEnemy = null;
+        this.services.battleService.enemies = [];
+        this.services.battleService.currentEnemy = null;
         const leavingHell = this.hells[this.currentHell];
         if (leavingHell.exitEffect) {
           leavingHell.exitEffect();
         }
         this.currentHell = -1;
-        this.activityService.reloadActivities();
+        this.services.activityService.reloadActivities();
       }],
       requirements: [{
       }],
@@ -1086,15 +1081,15 @@ export class HellService {
   }
 
   setEnterHellsArray(newList: Activity[]) {
-    newList.push(this.activityService.Resting);
-    newList.push(this.activityService.CombatTraining);
-    newList.push(this.activityService.CoreCultivation);
-    newList.push(this.activityService.SoulCultivation);
-    newList.push(this.activityService.InfuseBody);
-    if (this.activityService.purifyGemsUnlocked) {
-      newList.push(this.activityService.PurifyGems);
+    newList.push(this.services.activityService.Resting);
+    newList.push(this.services.activityService.CombatTraining);
+    newList.push(this.services.activityService.CoreCultivation);
+    newList.push(this.services.activityService.SoulCultivation);
+    newList.push(this.services.activityService.InfuseBody);
+    if (this.services.activityService.purifyGemsUnlocked) {
+      newList.push(this.services.activityService.PurifyGems);
     }
-    newList.push(this.activityService.InfuseEquipment);
+    newList.push(this.services.activityService.InfuseEquipment);
     let allComplete = true;
     for (const hell of this.hells) {
       let consequenceDescription = "";
@@ -1118,7 +1113,7 @@ export class HellService {
           if (newHell.entryEffect) {
             newHell.entryEffect();
           }
-          this.activityService.reloadActivities();
+          this.services.activityService.reloadActivities();
         }],
         requirements: [{
         }],
@@ -1134,17 +1129,17 @@ export class HellService {
         description: ["You've had enough of this place and learned everything these hells can teach you. Challenge Lord Yama to prove you deserve your rightful place in the heavens."],
         consequenceDescription: [""],
         consequence: [() => {
-          if (this.battleService.enemies.length == 0){
-            this.battleService.addEnemy({
+          if (this.services.battleService.enemies.length == 0){
+            this.services.battleService.addEnemy({
               name: "Lord Yama",
               health: 1e40,
               maxHealth: 1e40,
               accuracy: 0.8,
               attack: 1e14,
               defense: 1e18,
-              loot: [this.itemRepoService.items['portalKey']]
+              loot: [this.services.itemRepoService.items['portalKey']]
             });
-            this.battleService.addEnemy({
+            this.services.battleService.addEnemy({
               name: "Horse Face",
               health: 1e39,
               maxHealth: 1e39,
@@ -1153,7 +1148,7 @@ export class HellService {
               defense: 5e17,
               loot: []
             });
-            this.battleService.addEnemy({
+            this.services.battleService.addEnemy({
               name: "Ox Head",
               health: 1e39,
               maxHealth: 1e39,
@@ -1173,31 +1168,32 @@ export class HellService {
     }
   }
 
-  hells: Hell[] = [
+  populateHells(): void {
+  this.hells = [
     {
       name: "Hell of Tongue-ripping",
       description: "Torment for gossips and everyone one who made trouble with their words. The demons here reach for your tongue to rip it out.",
       index: HellLevel.TongueRipping,
       entryEffect: () => {
-        this.followerService.stashFollowers();
+        this.services.followerService.stashFollowers();
       },
       dailyEffect: () => {
         // This might be a stupid way to nerf charisma. Consider other alternatives.
         const reducer = .9;
-        this.characterService.characterState.attributes.charisma.value *= reducer;
+        this.services.characterService.characterState.attributes.charisma.value *= reducer;
       },
       exitEffect: () => {
-        this.followerService.restoreFollowers();
+        this.services.followerService.restoreFollowers();
       },
       completeEffect: () => {
-        this.logService.addLogMessage("Together with your new followers, you have seized control of the Hell of Tongue-ripping. Now all that remains is to defeat its lord.", "STANDARD", "STORY")
+        this.services.logService.addLogMessage("Together with your new followers, you have seized control of the Hell of Tongue-ripping. Now all that remains is to defeat its lord.", "STANDARD", "STORY")
       },
-      activities: [this.activityService.Resting, this.activityService.MindCultivation, this.activityService.BodyCultivation, this.activityService.CoreCultivation, this.activityService.SoulCultivation, this.hellRecruiting, this.activityService.TrainingFollowers],
-      projectionActivities: [this.activityService.OddJobs, this.burnMoney],
+      activities: [this.services.activityService.Resting, this.services.activityService.MindCultivation, this.services.activityService.BodyCultivation, this.services.activityService.CoreCultivation, this.services.activityService.SoulCultivation, this.activities['hellRecruiting'], this.services.activityService.TrainingFollowers],
+      projectionActivities: [this.services.activityService.OddJobs, this.activities['burnMoney']],
       hint: "It's hard to talk with all these demons going for your mouth, but maybe if you can get some help from the other prisoners here you could take control of this place.",
       progress: () => {
         let totalPower = 0;
-        for (const follower of this.followerService.followers) {
+        for (const follower of this.services.followerService.followers) {
           totalPower += follower.power;
         }
         return totalPower;
@@ -1207,7 +1203,7 @@ export class HellService {
       },
       successCheck: () => {
         let totalPower = 0;
-        for (const follower of this.followerService.followers) {
+        for (const follower of this.services.followerService.followers) {
           totalPower += follower.power;
         }
         return totalPower > 5000;
@@ -1218,25 +1214,25 @@ export class HellService {
       description: "Torment for those who ruin marriages. The demons here will cut your fingers right off.",
       index: HellLevel.Scissors,
       entryEffect: () => {
-        this.inventoryService.stashWeapons();
+        this.services.inventoryService.stashWeapons();
       },
       exitEffect: () => {
-        this.inventoryService.restoreWeapons();
+        this.services.inventoryService.restoreWeapons();
       },
       completeEffect: () => {
-        this.logService.addLogMessage("Using nothing but the strength of your body and mind, you have seized control of the Hell of Scissors. Now all that remains is to defeat its lord.", "STANDARD", "STORY")
+        this.services.logService.addLogMessage("Using nothing but the strength of your body and mind, you have seized control of the Hell of Scissors. Now all that remains is to defeat its lord.", "STANDARD", "STORY")
       },
-      activities: [this.activityService.Resting, this.activityService.MindCultivation, this.activityService.BodyCultivation, this.activityService.CoreCultivation, this.activityService.SoulCultivation, this.activityService.Taunting],
-      projectionActivities: [this.activityService.OddJobs, this.burnMoney],
+      activities: [this.services.activityService.Resting, this.services.activityService.MindCultivation, this.services.activityService.BodyCultivation, this.services.activityService.CoreCultivation, this.services.activityService.SoulCultivation, this.services.activityService.Taunting],
+      projectionActivities: [this.services.activityService.OddJobs, this.activities['burnMoney']],
       hint: "These demons don't seem content to just take your fingers. You'd better get ready to defend yourself.",
       progress: () => {
-        return this.inventoryService.getQuantityByName("fingers");
+        return this.services.inventoryService.getQuantityByName("fingers");
       },
       progressMax: () => {
         return 100;
       },
       successCheck: () => {
-        return this.inventoryService.getQuantityByName("fingers") >= 100;
+        return this.services.inventoryService.getQuantityByName("fingers") >= 100;
       }
     },
     {
@@ -1244,31 +1240,31 @@ export class HellService {
       description: "Torment for those who cause trouble between family members. The demons here will tie you to a tree made of sharp knives",
       index: HellLevel.TreesOfKnives,
       entryEffect: () => {
-        this.characterService.stashMoney();
+        this.services.characterService.stashMoney();
       },
       dailyEffect: () => {
         // lose 10% of your health every day
-        const damage = (this.characterService.characterState.status.health.value * 0.1);
-        this.logService.addLogMessage("The knives dig into your flesh, causing " + damage + " damage.", "INJURY", "COMBAT");
-        this.characterService.characterState.status.health.value -= damage;
+        const damage = (this.services.characterService.characterState.status.health.value * 0.1);
+        this.services.logService.addLogMessage("The knives dig into your flesh, causing " + damage + " damage.", "INJURY", "COMBAT");
+        this.services.characterService.characterState.status.health.value -= damage;
       },
       exitEffect: () => {
-        this.characterService.restoreMoney();
+        this.services.characterService.restoreMoney();
       },
       completeEffect: () => {
-        this.logService.addLogMessage("You have reconciled yourself with all of your family members and satisfied the demands of this hell. Now all that remains is to defeat its lord (while still tied to this tree).", "STANDARD", "STORY")
+        this.services.logService.addLogMessage("You have reconciled yourself with all of your family members and satisfied the demands of this hell. Now all that remains is to defeat its lord (while still tied to this tree).", "STANDARD", "STORY")
       },
-      activities: [this.activityService.Resting, this.activityService.MindCultivation, this.activityService.BodyCultivation, this.activityService.CoreCultivation, this.activityService.SoulCultivation, this.honorAncestors],
-      projectionActivities: [this.activityService.OddJobs, this.burnMoney],
+      activities: [this.services.activityService.Resting, this.services.activityService.MindCultivation, this.services.activityService.BodyCultivation, this.services.activityService.CoreCultivation, this.services.activityService.SoulCultivation, this.activities['honorAncestors']],
+      projectionActivities: [this.services.activityService.OddJobs, this.activities['burnMoney']],
       hint: "Heal your family bonds.",
       progress: () => {
-        return this.inventoryService.getQuantityByName("token of gratitude");
+        return this.services.inventoryService.getQuantityByName("token of gratitude");
       },
       progressMax: () => {
         return 10000;
       },
       successCheck: () => {
-        return this.inventoryService.getQuantityByName("token of gratitude") >= 10000;
+        return this.services.inventoryService.getQuantityByName("token of gratitude") >= 10000;
       }
     },
     {
@@ -1276,26 +1272,26 @@ export class HellService {
       description: "Torment for those who escaped punishment for their crimes. The mirrors here shine with a terrifying glow.",
       index: HellLevel.Mirrors,
       entryEffect: () => {
-        this.followerService.stashFollowers();
+        this.services.followerService.stashFollowers();
       },
       exitEffect: () => {
-        this.followerService.restoreFollowers();
+        this.services.followerService.restoreFollowers();
       },
       completeEffect: () => {
-        this.inventoryService.consume("mirrorShard", 1000);
-        this.logService.addLogMessage("You piece together the shards of mirror that you have collected to form a new mirror. A dark shape looms beyond it.", "STANDARD", "STORY")
+        this.services.inventoryService.consume("mirrorShard", 1000);
+        this.services.logService.addLogMessage("You piece together the shards of mirror that you have collected to form a new mirror. A dark shape looms beyond it.", "STANDARD", "STORY")
       },
-      activities: [this.activityService.Resting, this.activityService.CombatTraining, this.activityService.MindCultivation, this.activityService.BodyCultivation, this.activityService.CoreCultivation, this.activityService.SoulCultivation, this.activityService.Taunting],
-      projectionActivities: [this.activityService.OddJobs, this.burnMoney],
+      activities: [this.services.activityService.Resting, this.services.activityService.CombatTraining, this.services.activityService.MindCultivation, this.services.activityService.BodyCultivation, this.services.activityService.CoreCultivation, this.services.activityService.SoulCultivation, this.services.activityService.Taunting],
+      projectionActivities: [this.services.activityService.OddJobs, this.activities['burnMoney']],
       hint: "Master yourself. All by yourself.",
       progress: () => {
-        return this.inventoryService.getQuantityByName("mirror shard");
+        return this.services.inventoryService.getQuantityByName("mirror shard");
       },
       progressMax: () => {
         return 1000;
       },
       successCheck: () => {
-        return this.inventoryService.getQuantityByName("mirror shard") >= 1000;
+        return this.services.inventoryService.getQuantityByName("mirror shard") >= 1000;
       }
     },
     {
@@ -1303,35 +1299,35 @@ export class HellService {
       description: "Torment for hypocrites and troublemakers. The steam baskets here are just the right size for you.",
       index: HellLevel.Steamers,
       entryEffect: () => {
-        this.inventoryService.stashWeapons();
-        this.inventoryService.stashArmor();
+        this.services.inventoryService.stashWeapons();
+        this.services.inventoryService.stashArmor();
       },
       exitEffect: () => {
-        this.inventoryService.restoreWeapons();
-        this.inventoryService.restoreArmor();
+        this.services.inventoryService.restoreWeapons();
+        this.services.inventoryService.restoreArmor();
       },
       dailyEffect: () => {
         // take damage from the steam and get robbed by troublemakers
-        if (this.inventoryService.consume("iceCore") < 0) {
-          const damage = (this.characterService.characterState.status.health.value * 0.05);
-          this.logService.addLogMessage("The steam cooks your skin, causing " + damage + " damage.", "INJURY", "COMBAT");
-          this.characterService.characterState.status.health.value -= damage;
+        if (this.services.inventoryService.consume("iceCore") < 0) {
+          const damage = (this.services.characterService.characterState.status.health.value * 0.05);
+          this.services.logService.addLogMessage("The steam cooks your skin, causing " + damage + " damage.", "INJURY", "COMBAT");
+          this.services.characterService.characterState.status.health.value -= damage;
         }
         if (Math.random() < 0.2) {
-          this.logService.addLogMessage("As if the constant scalding steam isn't enough, one of these troublemakers stole some money! Why does this feel so familiar?", "STANDARD", "EVENT")
-          this.characterService.characterState.hellMoney -= this.characterService.characterState.hellMoney * 0.1;
+          this.services.logService.addLogMessage("As if the constant scalding steam isn't enough, one of these troublemakers stole some money! Why does this feel so familiar?", "STANDARD", "EVENT")
+          this.services.characterService.characterState.hellMoney -= this.services.characterService.characterState.hellMoney * 0.1;
         }
       },
       completeEffect: () => {
-        this.battleService.clearEnemies();
-        this.logService.addLogMessage("You defeat so many troublemakers that the rest all beg to return to their baskets for their regular torment.", "STANDARD", "STORY")
+        this.services.battleService.clearEnemies();
+        this.services.logService.addLogMessage("You defeat so many troublemakers that the rest all beg to return to their baskets for their regular torment.", "STANDARD", "STORY")
       },
-      activities: [this.activityService.Resting, this.activityService.MindCultivation, this.activityService.BodyCultivation, this.activityService.CoreCultivation, this.activityService.SoulCultivation, this.activityService.Taunting, this.rehabilitation],
-      projectionActivities: [this.activityService.OddJobs, this.burnMoney],
+      activities: [this.services.activityService.Resting, this.services.activityService.MindCultivation, this.services.activityService.BodyCultivation, this.services.activityService.CoreCultivation, this.services.activityService.SoulCultivation, this.services.activityService.Taunting, this.activities['rehabilitation']],
+      projectionActivities: [this.services.activityService.OddJobs, this.activities['burnMoney']],
       hint: "There so many troublemakers here that deserve some payback from you. I wonder if you can take them all on.",
       progress: () => {
         let totalEnemies = 0;
-        for (const enemyStack of this.battleService.enemies) {
+        for (const enemyStack of this.services.battleService.enemies) {
           totalEnemies += enemyStack.quantity;
         }
         return totalEnemies;
@@ -1341,7 +1337,7 @@ export class HellService {
       },
       successCheck: () => {
         let totalEnemies = 0;
-        for (const enemyStack of this.battleService.enemies) {
+        for (const enemyStack of this.services.battleService.enemies) {
           totalEnemies += enemyStack.quantity;
         }
         return totalEnemies > 100; // tune this
@@ -1352,33 +1348,33 @@ export class HellService {
       description: "Torment for arsonists. The red-hot copper pillars you will be bound to remind you of all those times you played with fire.",
       index: HellLevel.CopperPillars,
       entryEffect: () => {
-        this.inventoryService.stashWeapons();
+        this.services.inventoryService.stashWeapons();
       },
       exitEffect: () => {
-        this.inventoryService.restoreWeapons();
+        this.services.inventoryService.restoreWeapons();
       },
       dailyEffect: () => {
         // take damage from the pillar
-        if (this.inventoryService.consume("iceCore") < 0) {
-          const damage =  Math.max(this.characterService.characterState.status.health.value * 0.1, 20);
-          this.characterService.characterState.status.health.value -= damage;
-          this.logService.addLogMessage("The heat of the pillars burns you for " + damage + " damage.", "INJURY", "COMBAT");
+        if (this.services.inventoryService.consume("iceCore") < 0) {
+          const damage =  Math.max(this.services.characterService.characterState.status.health.value * 0.1, 20);
+          this.services.characterService.characterState.status.health.value -= damage;
+          this.services.logService.addLogMessage("The heat of the pillars burns you for " + damage + " damage.", "INJURY", "COMBAT");
         }
       },
       completeEffect: () => {
-        this.logService.addLogMessage("You finally forge a hammer powerful enough to break through the chains that bind you to the pillar. The Lord of this Hell comes to investigate all the commotion as the chains fall to the ground.", "STANDARD", "STORY")
+        this.services.logService.addLogMessage("You finally forge a hammer powerful enough to break through the chains that bind you to the pillar. The Lord of this Hell comes to investigate all the commotion as the chains fall to the ground.", "STANDARD", "STORY")
       },
-      activities: [this.activityService.Resting, this.activityService.MindCultivation, this.activityService.BodyCultivation, this.activityService.CoreCultivation, this.activityService.SoulCultivation, this.copperMining, this.forgeHammer],
-      projectionActivities: [this.activityService.OddJobs, this.burnMoney],
+      activities: [this.services.activityService.Resting, this.services.activityService.MindCultivation, this.services.activityService.BodyCultivation, this.services.activityService.CoreCultivation, this.services.activityService.SoulCultivation, this.activities['copperMining'], this.activities['forgeHammer']],
+      projectionActivities: [this.services.activityService.OddJobs, this.activities['burnMoney']],
       hint: "You'll need a really strong hammer to break through these hellsteel chain. Too bad the only material around is copper.",
       progress: () => {
-        return (this.characterService.characterState.equipment.rightHand?.weaponStats?.baseDamage || 0);
+        return (this.services.characterService.characterState.equipment.rightHand?.weaponStats?.baseDamage || 0);
       },
       progressMax: () => {
         return 100;
       },
       successCheck: () => {
-        return ((this.characterService.characterState.equipment.rightHand?.weaponStats?.baseDamage || 0) > 100); // tune this
+        return ((this.services.characterService.characterState.equipment.rightHand?.weaponStats?.baseDamage || 0) > 100); // tune this
       }
     },
     {
@@ -1387,31 +1383,31 @@ export class HellService {
       index: HellLevel.MountainOfKnives,
       dailyEffect: () => {
         // TODO: tune this
-        let damage = (this.battleService.totalKills / 10) - (this.mountainSteps * 10);
+        let damage = (this.services.battleService.totalKills / 10) - (this.mountainSteps * 10);
         if (damage < 0) {
           damage = 0;
         }
         
-        this.characterService.characterState.status.health.value -= damage;
+        this.services.characterService.characterState.status.health.value -= damage;
         if (damage > 0) {
-          this.logService.addLogMessage("The mountain's blades shred you for " + damage + " damage.", "INJURY", "COMBAT");
+          this.services.logService.addLogMessage("The mountain's blades shred you for " + damage + " damage.", "INJURY", "COMBAT");
         }
       },
       completeEffect: () => {
-        this.logService.addLogMessage("You finally reach the peak. The karmic weight of all the killing you've ever done drops from your shoulders. Now to defeat this hell's lord without taking any pleasure in the act.", "STANDARD", "STORY");
+        this.services.logService.addLogMessage("You finally reach the peak. The karmic weight of all the killing you've ever done drops from your shoulders. Now to defeat this hell's lord without taking any pleasure in the act.", "STANDARD", "STORY");
       },
-      activities: [this.activityService.Resting, this.activityService.MindCultivation, this.activityService.BodyCultivation, this.activityService.CoreCultivation, this.activityService.SoulCultivation, this.climbMountain],
-      projectionActivities: [this.activityService.OddJobs, this.burnMoney],
+      activities: [this.services.activityService.Resting, this.services.activityService.MindCultivation, this.services.activityService.BodyCultivation, this.services.activityService.CoreCultivation, this.services.activityService.SoulCultivation, this.activities['climbMountain']],
+      projectionActivities: [this.services.activityService.OddJobs, this.activities['burnMoney']],
       hint: "It seems you've accrued a lot of karma from all the killing you've done over your many lives. The bill is due.",
       progress: () => {
         return this.mountainSteps;
       },
       progressMax: () => {
-        return this.battleService.totalKills / 100;
+        return this.services.battleService.totalKills / 100;
       },
       successCheck: () => {
         // let's just say that 90% of our kills were justified and we didn't enjoy them one bit. Still gotta pay for the other 10%.
-        return this.mountainSteps >= this.battleService.totalKills / 100;
+        return this.mountainSteps >= this.services.battleService.totalKills / 100;
       }
     },
     {
@@ -1419,30 +1415,30 @@ export class HellService {
       description: "Torment for adulterers and schemers. The chill wind blowing through the gate is so cold it burns.",
       index: HellLevel.MountainOfIce,
       completeEffect: () => {
-        this.logService.addLogMessage("You realize that the power of the ice cores is all that prevents the heat from the neighboring hells from turning the mountain into slush. With enough of these tucked away in your pack, the mountain dwindles down to a managable size. Now to see who's in charge around here.", "STANDARD", "STORY");
+        this.services.logService.addLogMessage("You realize that the power of the ice cores is all that prevents the heat from the neighboring hells from turning the mountain into slush. With enough of these tucked away in your pack, the mountain dwindles down to a managable size. Now to see who's in charge around here.", "STANDARD", "STORY");
       },
       dailyEffect: () => {
         // TODO: tune this
         const damage = 1000;
-        if (this.inventoryService.consume("fireCore") < 0) {
-          this.characterService.characterState.status.health.value -= damage;
-          this.logService.addLogMessage("The mountain's ice freezes you for " + damage + " damage.", "INJURY", "COMBAT");
+        if (this.services.inventoryService.consume("fireCore") < 0) {
+          this.services.characterService.characterState.status.health.value -= damage;
+          this.services.logService.addLogMessage("The mountain's ice freezes you for " + damage + " damage.", "INJURY", "COMBAT");
         }
         // This might be a stupid way to nerf fireLore. Consider other alternatives.
         const reducer = .9;
-        this.characterService.characterState.attributes.fireLore.value *= reducer;
+        this.services.characterService.characterState.attributes.fireLore.value *= reducer;
       },
-      activities: [this.activityService.Resting, this.activityService.MindCultivation, this.activityService.BodyCultivation, this.activityService.CoreCultivation, this.activityService.SoulCultivation, this.activityService.Taunting, this.meltMountain],
-      projectionActivities: [this.activityService.OddJobs, this.burnMoney],
+      activities: [this.services.activityService.Resting, this.services.activityService.MindCultivation, this.services.activityService.BodyCultivation, this.services.activityService.CoreCultivation, this.services.activityService.SoulCultivation, this.services.activityService.Taunting, this.activities['meltMountain']],
+      projectionActivities: [this.services.activityService.OddJobs, this.activities['burnMoney']],
       hint: "Burn it down!",
       progress: () => {
-        return this.inventoryService.getQuantityByName("ice core");
+        return this.services.inventoryService.getQuantityByName("ice core");
       },
       progressMax: () => {
         return 10000;
       },
       successCheck: () => {
-        return this.inventoryService.getQuantityByName("ice core") >= 10000; // TODO: tune this
+        return this.services.inventoryService.getQuantityByName("ice core") >= 10000; // TODO: tune this
       }
     },
     {
@@ -1451,48 +1447,48 @@ export class HellService {
       index: HellLevel.CauldronsOfOil,
       dailyEffect: () => {
         if (!this.completedHellTasks.includes(HellLevel.CauldronsOfOil)) {
-          if (this.inventoryService.consume("iceCore") > 0) {
-            this.logService.addLogMessage("The ice cores you brought in with you make the oil sputter and pop, baking you in a cloud of superheated steam.", "INJURY", "EVENT");
-            this.characterService.characterState.status.health.value -= 100000;
+          if (this.services.inventoryService.consume("iceCore") > 0) {
+            this.services.logService.addLogMessage("The ice cores you brought in with you make the oil sputter and pop, baking you in a cloud of superheated steam.", "INJURY", "EVENT");
+            this.services.characterService.characterState.status.health.value -= 100000;
             return;
           }
           // take damage from the oil
-          const damage = Math.max(this.characterService.characterState.status.health.value * 0.1, 20)
-          this.logService.addLogMessage("The oil scorches you, causing " + damage + " damage.", "INJURY", "COMBAT");
-          this.characterService.characterState.status.health.value -= damage;
+          const damage = Math.max(this.services.characterService.characterState.status.health.value * 0.1, 20)
+          this.services.logService.addLogMessage("The oil scorches you, causing " + damage + " damage.", "INJURY", "COMBAT");
+          this.services.characterService.characterState.status.health.value -= damage;
         }
         // chance to drop weapon
         if (Math.random() < 0.1) {
-          this.logService.addLogMessage("Your weapons slip from your oily hands.", "INJURY", "COMBAT");
-          this.inventoryService.autoequipBestEnabled = false;
-          let item = this.characterService.characterState.equipment.rightHand;
+          this.services.logService.addLogMessage("Your weapons slip from your oily hands.", "INJURY", "COMBAT");
+          this.services.inventoryService.autoequipBestEnabled = false;
+          let item = this.services.characterService.characterState.equipment.rightHand;
           // check for existence and make sure there's an empty slot for it
           if (item) {
-            this.inventoryService.addItem(item as Item);
-            this.characterService.characterState.equipment.rightHand = null;
+            this.services.inventoryService.addItem(item as Item);
+            this.services.characterService.characterState.equipment.rightHand = null;
           }
-          item = this.characterService.characterState.equipment.leftHand;
+          item = this.services.characterService.characterState.equipment.leftHand;
           // check for existence and make sure there's an empty slot for it
           if (item) {
-            this.inventoryService.addItem(item as Item);
-            this.characterService.characterState.equipment.leftHand = null;
+            this.services.inventoryService.addItem(item as Item);
+            this.services.characterService.characterState.equipment.leftHand = null;
           }
         }
       },
       completeEffect: () => {
-        this.logService.addLogMessage("The pile of ice cores you brought in with you make the oil sputter and pop, but you are tough enough to withstand the superheated steam. Out of the cauldron now, you look around for the boss.", "STANDARD", "STORY");
+        this.services.logService.addLogMessage("The pile of ice cores you brought in with you make the oil sputter and pop, but you are tough enough to withstand the superheated steam. Out of the cauldron now, you look around for the boss.", "STANDARD", "STORY");
       },
-      activities: [this.activityService.Resting, this.activityService.MindCultivation, this.activityService.BodyCultivation, this.activityService.CoreCultivation, this.activityService.SoulCultivation,],
-      projectionActivities: [this.activityService.OddJobs, this.burnMoney],
+      activities: [this.services.activityService.Resting, this.services.activityService.MindCultivation, this.services.activityService.BodyCultivation, this.services.activityService.CoreCultivation, this.services.activityService.SoulCultivation,],
+      projectionActivities: [this.services.activityService.OddJobs, this.activities['burnMoney']],
       hint: "You'd need to be incredibly resilient to survive this place.",
       progress: () => {
-        return this.inventoryService.getQuantityByName("ice core");
+        return this.services.inventoryService.getQuantityByName("ice core");
       },
       progressMax: () => {
         return 1000;
       },
       successCheck: () => {
-        return this.inventoryService.getQuantityByName("ice core") >= 1000 && this.characterService.characterState.status.health.value > 100000;
+        return this.services.inventoryService.getQuantityByName("ice core") >= 1000 && this.services.characterService.characterState.status.health.value > 100000;
       }
     },
     {
@@ -1500,10 +1496,10 @@ export class HellService {
       description: "Torment for animal abusers. The cows are looking a little restless.",
       index: HellLevel.CattlePit,
       completeEffect: () => {
-        this.logService.addLogMessage("The horde of rampaging cattle finally seems to understand that you're not there to hurt them. They back off and leave you alone. All except for that really big cow over there.", "STANDARD", "STORY");
+        this.services.logService.addLogMessage("The horde of rampaging cattle finally seems to understand that you're not there to hurt them. They back off and leave you alone. All except for that really big cow over there.", "STANDARD", "STORY");
       },
-      activities: [this.activityService.Resting, this.activityService.MindCultivation, this.activityService.BodyCultivation, this.activityService.CoreCultivation, this.activityService.SoulCultivation, this.healAnimals],
-      projectionActivities: [this.activityService.OddJobs, this.burnMoney],
+      activities: [this.services.activityService.Resting, this.services.activityService.MindCultivation, this.services.activityService.BodyCultivation, this.services.activityService.CoreCultivation, this.services.activityService.SoulCultivation, this.activities['healAnimals']],
+      projectionActivities: [this.services.activityService.OddJobs, this.activities['burnMoney']],
       hint: "Look at those poor sick cows. And those other cows that for some reason are standing up on two legs and charging you with weapons.",
       progress: () => {
         return this.animalsHealed;
@@ -1525,10 +1521,10 @@ export class HellService {
         }
         // TODO: tune this
         const damage = 500;
-        this.characterService.characterState.status.health.value -= damage;
-        this.logService.addLogMessage("The boulder crushes you for " + damage + " damage.", "INJURY", "COMBAT");
+        this.services.characterService.characterState.status.health.value -= damage;
+        this.services.logService.addLogMessage("The boulder crushes you for " + damage + " damage.", "INJURY", "COMBAT");
         if (Math.random() < 0.1) {
-          this.battleService.addEnemy({
+          this.services.battleService.addEnemy({
             name: "An Annoying Imp",
             health: 10,
             maxHealth: 10,
@@ -1543,10 +1539,10 @@ export class HellService {
         this.boulderHeight = 0;
       },
       completeEffect: () => {
-        this.logService.addLogMessage("You hoist the boulder high over your head, then throw it high into the air. It lands with a satisfying thud. Unfortunately, it grows arms and legs and walks back to you, and this time it looks angry.", "STANDARD", "STORY");
+        this.services.logService.addLogMessage("You hoist the boulder high over your head, then throw it high into the air. It lands with a satisfying thud. Unfortunately, it grows arms and legs and walks back to you, and this time it looks angry.", "STANDARD", "STORY");
       },
-      activities: [this.activityService.Resting, this.activityService.MindCultivation, this.activityService.BodyCultivation, this.activityService.CoreCultivation, this.activityService.SoulCultivation, this.liftBoulder],
-      projectionActivities: [this.activityService.OddJobs, this.burnMoney],
+      activities: [this.services.activityService.Resting, this.services.activityService.MindCultivation, this.services.activityService.BodyCultivation, this.services.activityService.CoreCultivation, this.services.activityService.SoulCultivation, this.activities['liftBoulder']],
+      projectionActivities: [this.services.activityService.OddJobs, this.activities['burnMoney']],
       hint: "It's leg day. No, it's arm day. Must be both! Lift!",
       progress: () => {
         return this.boulderHeight;
@@ -1566,10 +1562,10 @@ export class HellService {
         this.daysFasted++;
       },
       completeEffect: () => {
-        this.logService.addLogMessage("Your righteous asceticism have served you well. The lord of this hell has arrived to deal with you personally.", "STANDARD", "STORY")
+        this.services.logService.addLogMessage("Your righteous asceticism have served you well. The lord of this hell has arrived to deal with you personally.", "STANDARD", "STORY")
       },
-      activities: [this.activityService.Resting, this.activityService.MindCultivation, this.activityService.BodyCultivation, this.activityService.CoreCultivation, this.activityService.SoulCultivation],
-      projectionActivities: [this.activityService.OddJobs, this.burnMoney],
+      activities: [this.services.activityService.Resting, this.services.activityService.MindCultivation, this.services.activityService.BodyCultivation, this.services.activityService.CoreCultivation, this.services.activityService.SoulCultivation],
+      projectionActivities: [this.services.activityService.OddJobs, this.activities['burnMoney']],
       hint: "You begin to feel remorse for your gluttony across your many lives. Perhaps a nice, long fast would help you feel better. Hopefully you can keep the demons from spoonfeeding you their fiery concoction.",
       progress: () => {
         return this.daysFasted;
@@ -1589,10 +1585,10 @@ export class HellService {
         this.swimDepth = 0;
       },
       completeEffect: () => {
-        this.logService.addLogMessage("You finally reach the bottom of the pool where you find a massive plug. When you pull it, the pool begins to drain, revealing the source of all this blood.", "STANDARD", "STORY")
+        this.services.logService.addLogMessage("You finally reach the bottom of the pool where you find a massive plug. When you pull it, the pool begins to drain, revealing the source of all this blood.", "STANDARD", "STORY")
       },
-      activities: [this.swim],
-      projectionActivities: [this.activityService.OddJobs, this.burnMoney],
+      activities: [this.activities['swim']],
+      projectionActivities: [this.services.activityService.OddJobs, this.activities['burnMoney']],
       hint: "Not this again!",
       progress: () => {
         return this.swimDepth;
@@ -1610,21 +1606,21 @@ export class HellService {
       index: HellLevel.WrongfulDead,
       entryEffect: () => {
         if (this.exitFound) {
-          if (!this.hells[HellLevel.WrongfulDead].activities.includes(this.teachTheWay)) {
-            this.hells[HellLevel.WrongfulDead].activities.push(this.teachTheWay);
+          if (!this.hells[HellLevel.WrongfulDead].activities.includes(this.activities['teachTheWay'])) {
+            this.hells[HellLevel.WrongfulDead].activities.push(this.activities['teachTheWay']);
           }
         }
       },
       dailyEffect: () => {
-        this.logService.addLogMessage("The constant storm saps you of 500 health and 100 stamina.", "INJURY", "COMBAT");
-        this.characterService.characterState.status.health.value -= 500;
-        this.characterService.characterState.status.stamina.value -= 100;
+        this.services.logService.addLogMessage("The constant storm saps you of 500 health and 100 stamina.", "INJURY", "COMBAT");
+        this.services.characterService.characterState.status.health.value -= 500;
+        this.services.characterService.characterState.status.stamina.value -= 100;
       },
       completeEffect: () => {
-        this.logService.addLogMessage("You sigh in relief as you usher the last of the damned out. The hell is finally empty. Well, empty except for the monstrous Hell Lord coming toward you.", "STANDARD", "STORY")
+        this.services.logService.addLogMessage("You sigh in relief as you usher the last of the damned out. The hell is finally empty. Well, empty except for the monstrous Hell Lord coming toward you.", "STANDARD", "STORY")
       },
-      activities: [this.activityService.Resting, this.activityService.MindCultivation, this.activityService.BodyCultivation, this.activityService.CoreCultivation, this.activityService.SoulCultivation, this.searchForExit],
-      projectionActivities: [this.activityService.OddJobs, this.burnMoney],
+      activities: [this.services.activityService.Resting, this.services.activityService.MindCultivation, this.services.activityService.BodyCultivation, this.services.activityService.CoreCultivation, this.services.activityService.SoulCultivation, this.activities['searchForExit']],
+      projectionActivities: [this.services.activityService.OddJobs, this.activities['burnMoney']],
       hint: "These people don't belong here. Get them out.",
       progress: () => {
         return this.soulsEscaped;
@@ -1641,10 +1637,10 @@ export class HellService {
       description: "Torment for tomb-raiders and grave-robbers. The demons here look awfully handy with those giant axes.",
       index: HellLevel.Dismemberment,
       completeEffect: () => {
-        this.logService.addLogMessage("As you help more of the damned here to resolve their crimes, an angry cry sounds through the hell. The lord has arrived.", "STANDARD", "STORY")
+        this.services.logService.addLogMessage("As you help more of the damned here to resolve their crimes, an angry cry sounds through the hell. The lord has arrived.", "STANDARD", "STORY")
       },
-      activities: [this.activityService.Resting, this.activityService.MindCultivation, this.activityService.BodyCultivation, this.activityService.CoreCultivation, this.activityService.SoulCultivation, this.interrogate],
-      projectionActivities: [this.activityService.OddJobs, this.burnMoney, this.recoverTreasure, this.replaceTreasure],
+      activities: [this.services.activityService.Resting, this.services.activityService.MindCultivation, this.services.activityService.BodyCultivation, this.services.activityService.CoreCultivation, this.services.activityService.SoulCultivation, this.activities['interrogate']],
+      projectionActivities: [this.services.activityService.OddJobs, this.activities['burnMoney'], this.activities['recoverTreasure'], this.activities['replaceTreasure']],
       hint: "Unloot those tombs.",
       progress: () => {
         return this.relicsReturned;
@@ -1663,26 +1659,26 @@ export class HellService {
       index: HellLevel.MountainOfFire,
       dailyEffect: () => {
         // take damage from the volcano
-        if (this.inventoryService.consume("iceCore") < 0) {
-          const damage = Math.max(this.characterService.characterState.status.health.value * 0.1, 20)
-          this.logService.addLogMessage("The oppressive heat of the volcano burns you for " + damage + " damage.", "INJURY", "COMBAT");
-          this.characterService.characterState.status.health.value -= damage;
+        if (this.services.inventoryService.consume("iceCore") < 0) {
+          const damage = Math.max(this.services.characterService.characterState.status.health.value * 0.1, 20)
+          this.services.logService.addLogMessage("The oppressive heat of the volcano burns you for " + damage + " damage.", "INJURY", "COMBAT");
+          this.services.characterService.characterState.status.health.value -= damage;
         }
       },
       completeEffect: () => {
-        this.logService.addLogMessage("You realize that the power of the fire cores is essential to keeping the lava in the volcano liquid. With enough of these tucked away in your pack, the the surface finally cools enough to turn back to stone. Someone is not happy with this change.", "STANDARD", "STORY");
+        this.services.logService.addLogMessage("You realize that the power of the fire cores is essential to keeping the lava in the volcano liquid. With enough of these tucked away in your pack, the the surface finally cools enough to turn back to stone. Someone is not happy with this change.", "STANDARD", "STORY");
       },
-      activities: [this.activityService.Resting, this.activityService.MindCultivation, this.activityService.BodyCultivation, this.activityService.CoreCultivation, this.activityService.SoulCultivation, this.freezeMountain],
-      projectionActivities: [this.activityService.OddJobs, this.burnMoney],
+      activities: [this.services.activityService.Resting, this.services.activityService.MindCultivation, this.services.activityService.BodyCultivation, this.services.activityService.CoreCultivation, this.services.activityService.SoulCultivation, this.activities['freezeMountain']],
+      projectionActivities: [this.services.activityService.OddJobs, this.activities['burnMoney']],
       hint: "How does this volcano stay so hot?",
       progress: () => {
-        return this.inventoryService.getQuantityByName("fire core");
+        return this.services.inventoryService.getQuantityByName("fire core");
       },
       progressMax: () => {
         return 10000;
       },
       successCheck: () => {
-        return this.inventoryService.getQuantityByName("fire core") >= 10000; // TODO: tune this
+        return this.services.inventoryService.getQuantityByName("fire core") >= 10000; // TODO: tune this
       }
     },
     {
@@ -1691,19 +1687,19 @@ export class HellService {
       description: "Torment for any who abused their power to oppress the weak. You don't look forward to being ground into immortal flour.",
       index: HellLevel.Mills,
       completeEffect: () => {
-        this.logService.addLogMessage("Your karmic debt for all the oppression you've ever inflicted is paid off. Now you just need to show the strongest demon here not to pick on the weak.", "STANDARD", "STORY")
+        this.services.logService.addLogMessage("Your karmic debt for all the oppression you've ever inflicted is paid off. Now you just need to show the strongest demon here not to pick on the weak.", "STANDARD", "STORY")
       },
-      activities: [this.endureTheMill],
+      activities: [this.activities['endureTheMill']],
       projectionActivities: [],
       hint: "Just endure.",
       progress: () => {
         return this.timesCrushed;
       },
       progressMax: () => {
-        return this.characterService.characterState.totalLives * 100;
+        return this.services.characterService.characterState.totalLives * 100;
       },
       successCheck: () => {
-        return this.timesCrushed > this.characterService.characterState.totalLives * 100;
+        return this.timesCrushed > this.services.characterService.characterState.totalLives * 100;
       }
     },
     {
@@ -1713,15 +1709,15 @@ export class HellService {
       dailyEffect: () => {
         if (this.contractsExamined <= 20000) {
           // saw damage
-          this.logService.addLogMessage("The saws tear into your flesh, causing 100 damage.", "INJURY", "COMBAT");
-          this.characterService.characterState.status.health.value -= 100;
+          this.services.logService.addLogMessage("The saws tear into your flesh, causing 100 damage.", "INJURY", "COMBAT");
+          this.services.characterService.characterState.status.health.value -= 100;
         }
       },
       completeEffect: () => {
-        this.logService.addLogMessage("You finally find article 131 of bylaw 8888 subsection 42(b)6.42 where paragraph fourty-eight clearly states that you have the right to confront the Hell Lord. Time to party!", "STANDARD", "STORY")
+        this.services.logService.addLogMessage("You finally find article 131 of bylaw 8888 subsection 42(b)6.42 where paragraph fourty-eight clearly states that you have the right to confront the Hell Lord. Time to party!", "STANDARD", "STORY")
       },
-      activities: [this.activityService.Resting, this.activityService.MindCultivation, this.activityService.BodyCultivation, this.activityService.CoreCultivation, this.activityService.SoulCultivation, this.examineContracts,],
-      projectionActivities: [this.activityService.OddJobs, this.burnMoney],
+      activities: [this.services.activityService.Resting, this.services.activityService.MindCultivation, this.services.activityService.BodyCultivation, this.services.activityService.CoreCultivation, this.services.activityService.SoulCultivation, this.activities['examineContracts'],],
+      projectionActivities: [this.services.activityService.OddJobs, this.activities['burnMoney']],
       hint: "You read legalese, right?",
       progress: () => {
         return this.contractsExamined;
@@ -1735,6 +1731,6 @@ export class HellService {
       }
     }
   ]
-
+}
 
 }

--- a/src/app/game-state/home.service.ts
+++ b/src/app/game-state/home.service.ts
@@ -1,12 +1,6 @@
-import { Injectable, Injector } from '@angular/core';
-import { BattleService } from './battle.service';
-import { LogService } from './log.service';
-import { MainLoopService } from './main-loop.service';
-import { ReincarnationService } from './reincarnation.service';
-import { CharacterService } from './character.service';
-import { Furniture, InventoryService } from './inventory.service';
-import { ItemRepoService } from './item-repo.service';
-import { HellService } from './hell.service';
+import { Injectable } from '@angular/core';
+import { Furniture } from './inventory.service';
+import { ServicesService } from './services.service';
 
 export interface Home {
   name: string;
@@ -90,7 +84,6 @@ export type FurnitureSlots = { [key in FurniturePosition]: Furniture | null };
   providedIn: 'root'
 })
 export class HomeService {
-  hellService?: HellService
   autoBuyLandUnlocked = false;
   autoBuyLandLimit = 5;
   autoBuyHomeUnlocked = false;
@@ -106,8 +99,8 @@ export class HomeService {
   autoFieldLimit = 0;
   useAutoBuyReserve = false;
   autoBuyReserveAmount = 0;
-  land: number;
-  landPrice: number;
+  land = 0;
+  landPrice = 100;
   fields: Field[] = [];
   extraFields = 0;
   averageYield = 0; // running average of how much food is produced
@@ -139,11 +132,11 @@ export class HomeService {
       upgradeToTooltip: "Get a better house.",
       consequence: () => {
         if (Math.random() < 0.05) {
-          this.logService.addLogMessage("Some troublemakers stole some money while you were sleeping. It might be time to get some walls.", 'INJURY', 'EVENT');
-          this.characterService.characterState.money -= (this.characterService.characterState.money / 10);
+          this.services.logService.addLogMessage("Some troublemakers stole some money while you were sleeping. It might be time to get some walls.", 'INJURY', 'EVENT');
+          this.services.characterService.characterState.money -= (this.services.characterService.characterState.money / 10);
         }
         if (Math.random() < 0.4) {
-          this.battleService.addEnemy({
+          this.services.battleService.addEnemy({
             name: "a pesky mouse",
             health: 2,
             maxHealth: 2,
@@ -167,14 +160,14 @@ export class HomeService {
       maxInventory: 12,
       upgradeToTooltip: "Get a better house. A better home will cost 100 taels and take up 1 land. The new home will restore 1 stamina and a bit of health each night.",
       consequence: () => {
-        this.characterService.characterState.status.health.value += .5;
-        this.characterService.characterState.status.stamina.value += 1;
+        this.services.characterService.characterState.status.health.value += .5;
+        this.services.characterService.characterState.status.stamina.value += 1;
         if (Math.random() < 0.03) {
-          this.logService.addLogMessage("Some troublemakers stole some money while you were sleeping. It might be time to get some walls.", 'INJURY', 'EVENT');
-          this.characterService.characterState.money -= (this.characterService.characterState.money / 10);
+          this.services.logService.addLogMessage("Some troublemakers stole some money while you were sleeping. It might be time to get some walls.", 'INJURY', 'EVENT');
+          this.services.characterService.characterState.money -= (this.services.characterService.characterState.money / 10);
         }
         if (Math.random() < 0.2) {
-          this.battleService.addEnemy({
+          this.services.battleService.addEnemy({
             name: "a pesky mouse",
             health: 2,
             maxHealth: 2,
@@ -184,7 +177,7 @@ export class HomeService {
             loot: []
           });
         }
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.checkOverage();
       },
       furnitureSlots: [],
       daysToBuild: 1
@@ -199,9 +192,9 @@ export class HomeService {
       maxInventory: 15,
       upgradeToTooltip: "Get a better house. A better home will cost 1,000 taels and take up 5 land. The new home will restore 3 stamina and a bit of health each night. It also has walls and space to properly sleep.",
       consequence: () => {
-        this.characterService.characterState.status.health.value += .5;
-        this.characterService.characterState.status.stamina.value += 3;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.health.value += .5;
+        this.services.characterService.characterState.status.stamina.value += 3;
+        this.services.characterService.characterState.checkOverage();
       },
       furnitureSlots: [
         'bed'
@@ -218,9 +211,9 @@ export class HomeService {
       maxInventory: 18,
       upgradeToTooltip: "Get a better house. A better home will cost 10,000 taels and take up 10 land. The new home will restore 5 stamina and a bit of health each night. It has enough room to properly bathe.",
       consequence: () => {
-        this.characterService.characterState.status.health.value += .7;
-        this.characterService.characterState.status.stamina.value += 5;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.health.value += .7;
+        this.services.characterService.characterState.status.stamina.value += 5;
+        this.services.characterService.characterState.checkOverage();
       },
       furnitureSlots: [
         'bed',
@@ -238,10 +231,10 @@ export class HomeService {
       maxInventory: 20,
       upgradeToTooltip: "Get a better house. A better home will cost 100,000 taels and take up 20 land. The new home will restore 10 stamina and 1 health and a bit of mana each night. It also has room to let you cook.",
       consequence: () => {
-        this.characterService.characterState.status.mana.value += 0.1;
-        this.characterService.characterState.status.health.value += 1;
-        this.characterService.characterState.status.stamina.value += 10;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.mana.value += 0.1;
+        this.services.characterService.characterState.status.health.value += 1;
+        this.services.characterService.characterState.status.stamina.value += 10;
+        this.services.characterService.characterState.checkOverage();
       },
       furnitureSlots: [
         'bed',
@@ -260,10 +253,10 @@ export class HomeService {
       maxInventory: 24,
       upgradeToTooltip: "Get a better house. A better home will cost 1M taels and take up 50 land. The new home will restore 15 stamina, 2 health, and a bit of mana each night. It has room to practice your craft.",
       consequence: () => {
-        this.characterService.characterState.status.mana.value += 0.2;
-        this.characterService.characterState.status.health.value += 2;
-        this.characterService.characterState.status.stamina.value += 15;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.mana.value += 0.2;
+        this.services.characterService.characterState.status.health.value += 2;
+        this.services.characterService.characterState.status.stamina.value += 15;
+        this.services.characterService.characterState.checkOverage();
       },
       furnitureSlots: [
         'bed',
@@ -283,10 +276,10 @@ export class HomeService {
       maxInventory: 28,
       upgradeToTooltip: "Get a better house. A better home will cost 10m taels and take up 80 land. The new home will restore 20 stamina, 3 health, and a bit of mana each night.",
       consequence: () => {
-        this.characterService.characterState.status.mana.value += 0.3;
-        this.characterService.characterState.status.health.value += 3;
-        this.characterService.characterState.status.stamina.value += 20;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.mana.value += 0.3;
+        this.services.characterService.characterState.status.health.value += 3;
+        this.services.characterService.characterState.status.stamina.value += 20;
+        this.services.characterService.characterState.checkOverage();
       },
       furnitureSlots: [
         'bed',
@@ -306,10 +299,10 @@ export class HomeService {
       maxInventory: 30,
       upgradeToTooltip: "Get a better house. A better home will cost 100m taels and take up 100 land. The new home will restore 25 stamina, 4 health, and a bit of mana each night.",
       consequence: () => {
-        this.characterService.characterState.status.mana.value += 0.4;
-        this.characterService.characterState.status.health.value += 4;
-        this.characterService.characterState.status.stamina.value += 25;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.mana.value += 0.4;
+        this.services.characterService.characterState.status.health.value += 4;
+        this.services.characterService.characterState.status.stamina.value += 25;
+        this.services.characterService.characterState.checkOverage();
       },
       furnitureSlots: [
         'bed',
@@ -329,10 +322,10 @@ export class HomeService {
       maxInventory: 32,
       upgradeToTooltip: "Get a better house. A better home will cost 1B taels and take up 120 land. The new home will restore 30 stamina, 5 health, and a bit of mana each night.",
       consequence: () => {
-        this.characterService.characterState.status.mana.value += 0.5;
-        this.characterService.characterState.status.health.value += 5;
-        this.characterService.characterState.status.stamina.value += 30;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.mana.value += 0.5;
+        this.services.characterService.characterState.status.health.value += 5;
+        this.services.characterService.characterState.status.stamina.value += 30;
+        this.services.characterService.characterState.checkOverage();
       },
       furnitureSlots: [
         'bed',
@@ -352,10 +345,10 @@ export class HomeService {
       maxInventory: 36,
       upgradeToTooltip: "Get a better house. A better home will cost 10B taels and take up 150 land. The new home will restore 35 stamina, 10 health, and 1 mana each night.",
       consequence: () => {
-        this.characterService.characterState.status.mana.value += 1;
-        this.characterService.characterState.status.health.value += 10;
-        this.characterService.characterState.status.stamina.value += 35;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.mana.value += 1;
+        this.services.characterService.characterState.status.health.value += 10;
+        this.services.characterService.characterState.status.stamina.value += 35;
+        this.services.characterService.characterState.checkOverage();
       },
       furnitureSlots: [
         'bed',
@@ -375,10 +368,10 @@ export class HomeService {
       maxInventory: 40,
       upgradeToTooltip: "Get a better house. A better home will cost 100B taels and take up 150 land. The new home will restore 40 stamina, 15 health, and 2 mana each night.",
       consequence: () => {
-        this.characterService.characterState.status.mana.value += 2;
-        this.characterService.characterState.status.health.value += 15;
-        this.characterService.characterState.status.stamina.value += 40;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.mana.value += 2;
+        this.services.characterService.characterState.status.health.value += 15;
+        this.services.characterService.characterState.status.stamina.value += 40;
+        this.services.characterService.characterState.checkOverage();
       },
       furnitureSlots: [
         'bed',
@@ -398,10 +391,10 @@ export class HomeService {
       maxInventory: 50,
       upgradeToTooltip: "Get a better house. A better home will cost 1T taels and take up 180 land. The new home will restore 50 stamina, 20 health, and 3 mana each night.",
       consequence: () => {
-        this.characterService.characterState.status.mana.value += 3;
-        this.characterService.characterState.status.health.value += 20;
-        this.characterService.characterState.status.stamina.value += 50;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.mana.value += 3;
+        this.services.characterService.characterState.status.health.value += 20;
+        this.services.characterService.characterState.status.stamina.value += 50;
+        this.services.characterService.characterState.checkOverage();
       },
       furnitureSlots: [
         'bed',
@@ -421,10 +414,10 @@ export class HomeService {
       maxInventory: 60,
       upgradeToTooltip: "Get a better house. A better home will cost 10T taels and take up 500 land. The new home will restore 100 stamina, 30 health, and 4 mana each night.",
       consequence: () => {
-        this.characterService.characterState.status.mana.value += 4;
-        this.characterService.characterState.status.health.value += 30;
-        this.characterService.characterState.status.stamina.value += 100;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.mana.value += 4;
+        this.services.characterService.characterState.status.health.value += 30;
+        this.services.characterService.characterState.status.stamina.value += 100;
+        this.services.characterService.characterState.checkOverage();
       },
       furnitureSlots: [
         'bed',
@@ -444,10 +437,10 @@ export class HomeService {
       maxInventory: 80,
       upgradeToTooltip: "Get a better house. A better home will cost 100T taels and take up 1,000 land. The new home will restore 200 stamina, 50 health, and 5 mana each night.",
       consequence: () => {
-        this.characterService.characterState.status.mana.value += 5;
-        this.characterService.characterState.status.health.value += 50;
-        this.characterService.characterState.status.stamina.value += 200;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.mana.value += 5;
+        this.services.characterService.characterState.status.health.value += 50;
+        this.services.characterService.characterState.status.stamina.value += 200;
+        this.services.characterService.characterState.checkOverage();
       },
       furnitureSlots: [
         'bed',
@@ -467,10 +460,10 @@ export class HomeService {
       maxInventory: 100,
       upgradeToTooltip: "Get a better house. A better home will cost 1q taels and take up 10,000 land. The new home will restore 300 stamina, 80 health, and 10 mana each night.",
       consequence: () => {
-        this.characterService.characterState.status.mana.value += 10;
-        this.characterService.characterState.status.health.value += 80;
-        this.characterService.characterState.status.stamina.value += 300;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.mana.value += 10;
+        this.services.characterService.characterState.status.health.value += 80;
+        this.services.characterService.characterState.status.stamina.value += 300;
+        this.services.characterService.characterState.checkOverage();
       },
       furnitureSlots: [
         'bed',
@@ -490,10 +483,10 @@ export class HomeService {
       maxInventory: 125,
       upgradeToTooltip: "Get a better house. A better home will cost 10q taels and take up 1,000,000 land. The new home will restore 500 stamina, 100 health, and 20 mana each night.",
       consequence: () => {
-        this.characterService.characterState.status.mana.value += 20;
-        this.characterService.characterState.status.health.value += 100;
-        this.characterService.characterState.status.stamina.value += 500;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.mana.value += 20;
+        this.services.characterService.characterState.status.health.value += 100;
+        this.services.characterService.characterState.status.stamina.value += 500;
+        this.services.characterService.characterState.checkOverage();
       },
       furnitureSlots: [
         'bed',
@@ -513,10 +506,10 @@ export class HomeService {
       maxInventory: 150,
       upgradeToTooltip: "Get a better house. A better home will cost 100q taels and take up 10,000,000 land. The new home will restore 1000 stamina, 150 health, and 30 mana each night.",
       consequence: () => {
-        this.characterService.characterState.status.mana.value += 30;
-        this.characterService.characterState.status.health.value += 150;
-        this.characterService.characterState.status.stamina.value += 1000;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.mana.value += 30;
+        this.services.characterService.characterState.status.health.value += 150;
+        this.services.characterService.characterState.status.stamina.value += 1000;
+        this.services.characterService.characterState.checkOverage();
       },
       furnitureSlots: [
         'bed',
@@ -540,19 +533,10 @@ export class HomeService {
   bestHome = 0;
 
   constructor(
-    private injector: Injector,
-    private characterService: CharacterService,
-    private inventoryService: InventoryService,
-    private logService: LogService,
-    private battleService: BattleService,
-    mainLoopService: MainLoopService,
-    reincarnationService: ReincarnationService,
-    private itemRepoService: ItemRepoService,
+    private services: ServicesService,
+  ) {}
 
-  ) {
-    setTimeout(() => this.hellService = this.injector.get(HellService));
-    this.land = 0;
-    this.landPrice = 100;
+  init(): HomeService {
     this.setCurrentHome(this.homesList[0]);
     if (this.home === undefined ||
       this.homeValue === undefined ||
@@ -560,8 +544,8 @@ export class HomeService {
       throw Error('Home service not initialized correctly.');
     }
 
-    mainLoopService.tickSubject.subscribe(() => {
-      if (this.characterService.characterState.dead) {
+    this.services.mainLoopService.tickSubject.subscribe(() => {
+      if (this.services.characterService.characterState.dead) {
         return;
       }
       if (this.upgrading) {
@@ -571,7 +555,7 @@ export class HomeService {
       if (this.nextHomeCost < 0) {
         this.nextHomeCost = 0;
       }
-      if (!this.hellService?.inHell || this.hellHome) {
+      if (!this.services.hellService?.inHell || this.hellHome) {
         this.home.consequence();
         for (const slot of this.furniturePositionsArray) {
           const furniturePiece = this.furniture[slot];
@@ -580,24 +564,24 @@ export class HomeService {
           }
         }
       }
-      if (!this.hellService?.inHell || this.hellFood) {
+      if (!this.services.hellService?.inHell || this.hellFood) {
         this.ageFields();
       }
-      if (!this.hellService?.inHell && !this.characterService.characterState.god){
-        if (this.home.costPerDay > this.characterService.characterState.money ) {
-          this.logService.addLogMessage("You can't afford the upkeep on your home. Some thugs rough you up over the debt. You better get some money, fast.", "INJURY", 'EVENT');
+      if (!this.services.hellService?.inHell && !this.services.characterService.characterState.god){
+        if (this.home.costPerDay > this.services.characterService.characterState.money ) {
+          this.services.logService.addLogMessage("You can't afford the upkeep on your home. Some thugs rough you up over the debt. You better get some money, fast.", "INJURY", 'EVENT');
           if (this.thugPause) {
-            mainLoopService.pause = true;
+            this.services.mainLoopService.pause = true;
           }
-          this.characterService.characterState.status.health.value -= 20;
-          this.characterService.characterState.money = 0;
+          this.services.characterService.characterState.status.health.value -= 20;
+          this.services.characterService.characterState.money = 0;
         } else {
-          this.characterService.characterState.money -= this.home.costPerDay;
+          this.services.characterService.characterState.money -= this.home.costPerDay;
         }
       }
     });
 
-    mainLoopService.longTickSubject.subscribe(() => {
+    this.services.mainLoopService.longTickSubject.subscribe(() => {
       if (this.land > this.highestLand) {
         this.highestLand = this.land;
       }
@@ -621,22 +605,24 @@ export class HomeService {
 
     });
 
-    reincarnationService.reincarnateSubject.subscribe(() => {
+    this.services.reincarnationService.reincarnateSubject.subscribe(() => {
       this.reset();
-      if (this.characterService.characterState.bloodlineRank >= 6) {
-        this.logService.addLogMessage("You reincarnate as one of your descendants and your family recognizes you as you age.", "STANDARD", 'EVENT');
-        if (this.characterService.characterState.bloodlineRank >= 7) {
-          this.logService.addLogMessage("Your family steps aside and assists your takeover of your Empire.", "STANDARD", 'EVENT');
+      if (this.services.characterService.characterState.bloodlineRank >= 6) {
+        this.services.logService.addLogMessage("You reincarnate as one of your descendants and your family recognizes you as you age.", "STANDARD", 'EVENT');
+        if (this.services.characterService.characterState.bloodlineRank >= 7) {
+          this.services.logService.addLogMessage("Your family steps aside and assists your takeover of your Empire.", "STANDARD", 'EVENT');
         } else {
-          this.logService.addLogMessage("Your family escorts you to your ancestral home and helps you get settled in.", "STANDARD", 'EVENT');
+          this.services.logService.addLogMessage("Your family escorts you to your ancestral home and helps you get settled in.", "STANDARD", 'EVENT');
         }
       } else if (this.grandfatherTent) {
-        this.logService.addLogMessage("Your grandfather gives you a bit of land and helps you set up a tent on it.", "STANDARD", 'EVENT');
+        this.services.logService.addLogMessage("Your grandfather gives you a bit of land and helps you set up a tent on it.", "STANDARD", 'EVENT');
         //and a few coins so you don't immediately get beat up for not having upkeep money for your house
-        this.characterService.characterState.money += 50;
+        this.services.characterService.characterState.money += 50;
         this.setCurrentHome(this.nextHome);
       }
     });
+
+    return this;
   }
 
   getProperties(): HomeProperties {
@@ -697,7 +683,7 @@ export class HomeService {
     for (const slot of this.furniturePositionsArray) {
       const savedFurniture = properties.furniture[slot];
       if (savedFurniture) {
-        this.furniture[slot] = this.itemRepoService.getFurnitureById(savedFurniture.id);
+        this.furniture[slot] = this.services.itemRepoService.getFurnitureById(savedFurniture.id);
       }
     }
     this.ownedFurniture = properties.ownedFurniture || [];
@@ -728,13 +714,13 @@ export class HomeService {
       // currently upgrading, bail out
       return;
     }
-    if (this.characterService.characterState.money >= this.nextHomeCost && this.land >= this.nextHome.landRequired) {
-      this.characterService.characterState.money -= this.nextHomeCost;
+    if (this.services.characterService.characterState.money >= this.nextHomeCost && this.land >= this.nextHome.landRequired) {
+      this.services.characterService.characterState.money -= this.nextHomeCost;
       this.land -= this.nextHome.landRequired;
       this.nextHomeCostReduction = 0;
       this.houseBuildingProgress = 0;
       this.upgrading = true;
-      this.logService.addLogMessage("You start upgrading your home to a " + this.nextHome.name, "STANDARD", 'EVENT');
+      this.services.logService.addLogMessage("You start upgrading your home to a " + this.nextHome.name, "STANDARD", 'EVENT');
     }
   }
 
@@ -748,12 +734,12 @@ export class HomeService {
       this.houseBuildingProgress = 1;
       this.upgrading = false;
       this.setCurrentHome(this.nextHome);
-      this.logService.addLogMessage("You finished upgrading your home. You now live in a " + this.home.name, "STANDARD", 'EVENT');
+      this.services.logService.addLogMessage("You finished upgrading your home. You now live in a " + this.home.name, "STANDARD", 'EVENT');
     }
   }
 
   reset() {
-    if (this.characterService.characterState.bloodlineRank < 6) {
+    if (this.services.characterService.characterState.bloodlineRank < 6) {
       this.setCurrentHome(this.homesList[0]);
       this.furniture.bed = null;
       this.furniture.bathtub = null;
@@ -761,11 +747,11 @@ export class HomeService {
       this.furniture.workbench = null;
       this.ownedFurniture = [];
     }
-    if (this.characterService.characterState.bloodlineRank < 7) {
+    if (this.services.characterService.characterState.bloodlineRank < 7) {
       this.upgrading = false;
       this.houseBuildingProgress = 1;
     }
-    this.inventoryService.changeMaxItems(this.home.maxInventory);
+    this.services.inventoryService.changeMaxItems(this.home.maxInventory);
     this.nextHomeCostReduction = 0;
     this.land = 0;
     this.landPrice = 100;
@@ -780,7 +766,7 @@ export class HomeService {
     this.home = this.getHomeFromValue(this.homeValue);
     this.nextHome = this.getNextHome();
     this.nextHomeCost = this.nextHome.cost - this.nextHomeCostReduction;
-    this.inventoryService.changeMaxItems(this.home.maxInventory);
+    this.services.inventoryService.changeMaxItems(this.home.maxInventory);
   }
 
   getHomeFromValue(value: HomeType): Home {
@@ -794,13 +780,13 @@ export class HomeService {
 
   getCrop(): Field {
     let cropIndex = 0;
-    if (this.characterService.characterState.attributes.woodLore.value > 1) {
-      cropIndex = Math.floor(Math.log2(this.characterService.characterState.attributes.woodLore.value));
+    if (this.services.characterService.characterState.attributes.woodLore.value > 1) {
+      cropIndex = Math.floor(Math.log2(this.services.characterService.characterState.attributes.woodLore.value));
     }
-    if (cropIndex >= this.inventoryService.farmFoodList.length) {
-      cropIndex = this.inventoryService.farmFoodList.length - 1;
+    if (cropIndex >= this.services.inventoryService.farmFoodList.length) {
+      cropIndex = this.services.inventoryService.farmFoodList.length - 1;
     }
-    const cropItem = this.inventoryService.farmFoodList[cropIndex];
+    const cropItem = this.services.inventoryService.farmFoodList[cropIndex];
     // more valuable crops yield less per field and take longer to harvest, tune this later
     return {
       cropName: cropItem.id,
@@ -883,10 +869,10 @@ export class HomeService {
           fieldYield = Math.floor(fieldYield * (this.fields.length + this.extraFields) / 300);
         }
         totalDailyYield += fieldYield;
-        if (this.hellService?.inHell && fieldYield > 0) {
+        if (this.services.hellService?.inHell && fieldYield > 0) {
           fieldYield = Math.max(fieldYield / 1000, 1);
         }
-        this.inventoryService.addItem(this.itemRepoService.items[this.fields[i].cropName], fieldYield);
+        this.services.inventoryService.addItem(this.services.itemRepoService.items[this.fields[i].cropName], fieldYield);
         this.fields[i] = this.getCrop();
       } else {
         this.fields[i].daysToHarvest--;
@@ -900,7 +886,7 @@ export class HomeService {
    * @returns count of actual purchase
    */
   buyLand(count: number): number {
-    const maximumCount = this.calculateAffordableLand(this.characterService.characterState.money);
+    const maximumCount = this.calculateAffordableLand(this.services.characterService.characterState.money);
     if (!maximumCount || !count) {
       return 0;
     }
@@ -913,8 +899,8 @@ export class HomeService {
     }
     increase = 10 * (count * (count - 1) / 2); //mathmatically increase by linear sum n (n + 1) / 2
     price = this.landPrice * count + increase;
-    if (this.characterService.characterState.money >= price) {
-      this.characterService.characterState.money -= price;
+    if (this.services.characterService.characterState.money >= price) {
+      this.services.characterService.characterState.money -= price;
       this.land += count;
       this.landPrice += 10 * count;
     }
@@ -934,10 +920,10 @@ export class HomeService {
   }
 
   buyFurniture(itemId: string) {
-    const item = this.itemRepoService.getFurnitureById(itemId)
+    const item = this.services.itemRepoService.getFurnitureById(itemId)
     if (item) {
-      if (this.characterService.characterState.money >= item.value) {
-        this.characterService.characterState.money -= item.value;
+      if (this.services.characterService.characterState.money >= item.value) {
+        this.services.characterService.characterState.money -= item.value;
         this.ownedFurniture.push(item.name);
         this.furniture[item.slot] = item;
       }

--- a/src/app/game-state/impossibleTask.service.ts
+++ b/src/app/game-state/impossibleTask.service.ts
@@ -6,6 +6,7 @@ import { MainLoopService } from './main-loop.service';
 import { ReincarnationService } from './reincarnation.service';
 import { ActivityService } from './activity.service';
 import { BattleService } from './battle.service';
+import { ServicesService } from './services.service';
 
 export enum ImpossibleTaskType {
   Swim,
@@ -144,16 +145,11 @@ export class ImpossibleTaskService {
   ];
 
   constructor(
-    private injector: Injector,
-    private logService: LogService,
-    private characterService: CharacterService,
-    private itemRepoService: ItemRepoService,
-    mainLoopService: MainLoopService,
-    reincarnationService: ReincarnationService,
-    private battleService: BattleService
-  ) {
+    private services: ServicesService
+  ) {}
 
-    mainLoopService.longTickSubject.subscribe(() => {
+  init(): ImpossibleTaskService {
+    this.services.mainLoopService.longTickSubject.subscribe(() => {
       if (this.nextTask >= this.tasks.length) {
         // all tasks done
         return;
@@ -166,9 +162,11 @@ export class ImpossibleTaskService {
       }
     });
 
-    reincarnationService.reincarnateSubject.subscribe(() => {
+    this.services.reincarnationService.reincarnateSubject.subscribe(() => {
       this.reset();
     });
+
+    return this;
   }
 
   markPriorCompletions() {
@@ -201,10 +199,7 @@ export class ImpossibleTaskService {
       }
     }
     this.activeTaskIndex = -1;
-    if (!this.activityService) {
-      this.activityService = this.injector.get(ActivityService);
-    }
-    this.activityService.reloadActivities();
+    this.services.activityService.reloadActivities();
   }
 
   getProperties(): ImpossibleTaskProperties {
@@ -261,10 +256,7 @@ export class ImpossibleTaskService {
       this.activeTaskIndex = properties.activeTaskIndex;
     }
     this.markPriorCompletions();
-    if (!this.activityService) {
-      this.activityService = this.injector.get(ActivityService);
-    }
-    this.activityService.reloadActivities();
+    this.services.activityService.reloadActivities();
   }
 
   checkCompletion() {
@@ -279,12 +271,9 @@ export class ImpossibleTaskService {
 
   startTask() {
     this.activeTaskIndex = this.nextTask;
-    if (!this.activityService) {
-      this.activityService = this.injector.get(ActivityService);
-    }
-    this.activityService.reloadActivities();
+    this.services.activityService.reloadActivities();
     if (this.activeTaskIndex === ImpossibleTaskType.OvercomeDeath) {
-      this.battleService.addEnemy({
+      this.services.battleService.addEnemy({
         name: "Death itself",
         health: 1e24,
         maxHealth: 1e24,
@@ -292,7 +281,7 @@ export class ImpossibleTaskService {
         attack: 3e8,
         defense: 3e8,
         loot: [
-          this.itemRepoService.items['immortality']
+          this.services.itemRepoService.items['immortality']
         ],
         unique: true
       });
@@ -305,10 +294,7 @@ export class ImpossibleTaskService {
       this.taskProgress[this.activeTaskIndex].progress = 0;
     }
     this.activeTaskIndex = -1;
-    if (!this.activityService) {
-      this.activityService = this.injector.get(ActivityService);
-    }
-    this.activityService.reloadActivities();
+    this.services.activityService.reloadActivities();
   }
 
 }

--- a/src/app/game-state/item-repo.service.ts
+++ b/src/app/game-state/item-repo.service.ts
@@ -1,32 +1,18 @@
-import { Injectable, Injector } from '@angular/core';
-import { ActivityService } from './activity.service';
-import { BattleService } from './battle.service';
-import { LogService } from './log.service';
-import { MainLoopService } from './main-loop.service';
-import { CharacterService } from './character.service';
-import { HomeService } from './home.service';
-import { Furniture, InventoryService, Item } from './inventory.service';
-import { ImpossibleTaskService, ImpossibleTaskType } from './impossibleTask.service';
-import { FollowersService } from './followers.service';
-import { AutoBuyerService } from './autoBuyer.service';
-import { GameStateService } from './game-state.service';
-import { HellLevel, HellService } from './hell.service';
+import { Injectable } from '@angular/core';
+import { Furniture, Item } from './inventory.service';
+import { ImpossibleTaskType } from './impossibleTask.service';
+import { HellLevel } from './hell.service';
+import { ServicesService } from './services.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ItemRepoService {
-  homeService?: HomeService;
-  activityService?: ActivityService;
-  inventoryService?: InventoryService;
-  battleService?: BattleService;
-  impossibleTaskService?: ImpossibleTaskService;
-  followerService?: FollowersService;
-  autoBuyerService?: AutoBuyerService;
-  gameStateService?: GameStateService;
-  hellService?: HellService;
+  furniture: { [key: string]: Furniture } = {};
+  items: { [key: string]: Item } = {};
 
-  furniture: { [key: string]: Furniture } = {
+  populateFurniture(): void {
+  this.furniture = {
     blanket: {
       id: 'blanket',
       name: "Blanket",
@@ -36,7 +22,7 @@ export class ItemRepoService {
       description: "A tattered blanket. Not much, but it could keep you warm at night. Increases daily stamina recovery by 1.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.status.stamina.value++;
+        this.services.characterService.characterState.status.stamina.value++;
       },
     },
     mat: {
@@ -48,9 +34,9 @@ export class ItemRepoService {
       description: "A thin woven mat to sleep on. Increases daily stamina recovery by 1 and restores a bit of health.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.status.stamina.value += 1;
-        this.characterService.characterState.status.health.value += 0.1;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.stamina.value += 1;
+        this.services.characterService.characterState.status.health.value += 0.1;
+        this.services.characterService.characterState.checkOverage();
       }
     },
     canopyBed: {
@@ -62,9 +48,9 @@ export class ItemRepoService {
       description: "A fine bed with a cover. Curtains keep the mosquitoes off you during the night. Increases daily stamina recovery by 2 and restores a bit of health.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.status.stamina.value += 2;
-        this.characterService.characterState.status.health.value += 0.2;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.stamina.value += 2;
+        this.services.characterService.characterState.status.health.value += 0.2;
+        this.services.characterService.characterState.checkOverage();
       }
     },
     heatedBed: {
@@ -76,9 +62,9 @@ export class ItemRepoService {
       description: "A bed built over a small clay oven. Keeps you toasty on even the coldest nights. Increases daily stamina recovery by 5 and improves health recovery.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.status.stamina.value += 5;
-        this.characterService.characterState.status.health.value += 1;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.stamina.value += 5;
+        this.services.characterService.characterState.status.health.value += 1;
+        this.services.characterService.characterState.checkOverage();
       }
     },
     bedOfNails: {
@@ -90,8 +76,8 @@ export class ItemRepoService {
       description: "A solid board with nails poking upwards. You won't sleep as well, but it is certain to toughen you up.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.status.stamina.value -= 1;
-        this.characterService.characterState.increaseAttribute('toughness', 0.1);
+        this.services.characterService.characterState.status.stamina.value -= 1;
+        this.services.characterService.characterState.increaseAttribute('toughness', 0.1);
       }
     },
     waterBucket: {
@@ -103,7 +89,7 @@ export class ItemRepoService {
       description: "A bucket of water that lets you splash water on your face. Increases charisma.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.increaseAttribute('charisma', 0.01);
+        this.services.characterService.characterState.increaseAttribute('charisma', 0.01);
       }
     },
     washBasin: {
@@ -115,7 +101,7 @@ export class ItemRepoService {
       description: "A wash basin with a rag to clean yourself. Increases charisma.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.increaseAttribute('charisma', 0.05);
+        this.services.characterService.characterState.increaseAttribute('charisma', 0.05);
       }
     },
     woodenTub: {
@@ -127,9 +113,9 @@ export class ItemRepoService {
       description: "A tall and narrow tub where you can squat and bathe. Increases charisma and health recovery.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.increaseAttribute('charisma', 0.1);
-        this.characterService.characterState.status.health.value += 1;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.increaseAttribute('charisma', 0.1);
+        this.services.characterService.characterState.status.health.value += 1;
+        this.services.characterService.characterState.checkOverage();
       }
     },
     bronzeTub: {
@@ -141,9 +127,9 @@ export class ItemRepoService {
       description: "A luxurious tub where you can get sparkling clean. Increases charisma and health recovery.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.increaseAttribute('charisma', 0.2);
-        this.characterService.characterState.status.health.value += 1;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.increaseAttribute('charisma', 0.2);
+        this.services.characterService.characterState.status.health.value += 1;
+        this.services.characterService.characterState.checkOverage();
       }
     },
     heatedTub: {
@@ -155,11 +141,11 @@ export class ItemRepoService {
       description: "A luxurious tub with its own heating stove. Good for your health and beauty.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.increaseAttribute('charisma', 0.2);
-        this.characterService.characterState.status.stamina.value += 5;
-        this.characterService.characterState.status.health.value += 1;
-        this.characterService.characterState.healthBonusBath++;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.increaseAttribute('charisma', 0.2);
+        this.services.characterService.characterState.status.stamina.value += 5;
+        this.services.characterService.characterState.status.health.value += 1;
+        this.services.characterService.characterState.healthBonusBath++;
+        this.services.characterService.characterState.checkOverage();
       }
     },
     cookPot: {
@@ -171,9 +157,9 @@ export class ItemRepoService {
       description: "A simple pot over a fire to boil your food. Improves all physical attributes.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.increaseAttribute('strength', 0.01);
-        this.characterService.characterState.increaseAttribute('speed', 0.01);
-        this.characterService.characterState.increaseAttribute('toughness', 0.01);
+        this.services.characterService.characterState.increaseAttribute('strength', 0.01);
+        this.services.characterService.characterState.increaseAttribute('speed', 0.01);
+        this.services.characterService.characterState.increaseAttribute('toughness', 0.01);
       }
     },
     roastingSpit: {
@@ -185,9 +171,9 @@ export class ItemRepoService {
       description: "A simple spit to go along with your cookpot, letting you add more variety to your diet. Improves all physical attributes.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.increaseAttribute('strength', 0.02);
-        this.characterService.characterState.increaseAttribute('speed', 0.02);
-        this.characterService.characterState.increaseAttribute('toughness', 0.02);
+        this.services.characterService.characterState.increaseAttribute('strength', 0.02);
+        this.services.characterService.characterState.increaseAttribute('speed', 0.02);
+        this.services.characterService.characterState.increaseAttribute('toughness', 0.02);
       }
     },
     wok: {
@@ -199,9 +185,9 @@ export class ItemRepoService {
       description: "A large metal wok to stir-fry a tasty dinner. Improves all physical attributes.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.increaseAttribute('strength', 0.05);
-        this.characterService.characterState.increaseAttribute('speed', 0.05);
-        this.characterService.characterState.increaseAttribute('toughness', 0.05);
+        this.services.characterService.characterState.increaseAttribute('strength', 0.05);
+        this.services.characterService.characterState.increaseAttribute('speed', 0.05);
+        this.services.characterService.characterState.increaseAttribute('toughness', 0.05);
       }
     },
     chefKitchen: {
@@ -213,9 +199,9 @@ export class ItemRepoService {
       description: "An elaborate kitchen that allows you to cook anything. Improves all physical attributes.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.increaseAttribute('strength', 0.1);
-        this.characterService.characterState.increaseAttribute('speed', 0.1);
-        this.characterService.characterState.increaseAttribute('toughness', 0.1);
+        this.services.characterService.characterState.increaseAttribute('strength', 0.1);
+        this.services.characterService.characterState.increaseAttribute('speed', 0.1);
+        this.services.characterService.characterState.increaseAttribute('toughness', 0.1);
       }
     },
     anvil: {
@@ -227,7 +213,7 @@ export class ItemRepoService {
       description: "An anvil to work on blacksmithing.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.increaseAttribute('metalLore', 0.01);
+        this.services.characterService.characterState.increaseAttribute('metalLore', 0.01);
       }
     },
     herbGarden: {
@@ -239,7 +225,7 @@ export class ItemRepoService {
       description: "An pleasant garden growing herbs.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.increaseAttribute('woodLore', 0.01);
+        this.services.characterService.characterState.increaseAttribute('woodLore', 0.01);
       }
     },
     dogKennel: {
@@ -251,7 +237,7 @@ export class ItemRepoService {
       description: "A kennel for training hunting dogs.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.increaseAttribute('animalHandling', 0.01);
+        this.services.characterService.characterState.increaseAttribute('animalHandling', 0.01);
       }
     },
     cauldron: {
@@ -263,7 +249,7 @@ export class ItemRepoService {
       description: "A cauldron for practicing alchemy.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.increaseAttribute('waterLore', 0.01);
+        this.services.characterService.characterState.increaseAttribute('waterLore', 0.01);
       }
     },
     bookshelf: {
@@ -275,7 +261,7 @@ export class ItemRepoService {
       description: "An bookshelf to read and expand your mind.",
       useConsumes: false,
       use: () => {
-        this.characterService.characterState.increaseAttribute('intelligence', 0.1);
+        this.services.characterService.characterState.increaseAttribute('intelligence', 0.1);
       }
     },
     prayerShrine: {
@@ -287,14 +273,16 @@ export class ItemRepoService {
       description: "A quiet shrine for contemplative prayer. You won't be able to use this unless you have some innate spirituality.",
       useConsumes: false,
       use: () => {
-        if (this.characterService.characterState.attributes.spirituality.value > 0) {
-          this.characterService.characterState.increaseAttribute('spirituality', 0.01);
+        if (this.services.characterService.characterState.attributes.spirituality.value > 0) {
+          this.services.characterService.characterState.increaseAttribute('spirituality', 0.01);
         }
       }
     }
   }
+}
 
-  items: { [key: string]: Item } = {
+  populateItems(): void {
+  this.items = {
     rice: {
       id: 'rice',
       name: 'rice',
@@ -305,8 +293,8 @@ export class ItemRepoService {
       useDescription: 'Fills your belly.',
       useConsumes: true,
       use: (quantity = 1) => {
-        this.characterService.characterState.status.nourishment.value += quantity;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.nourishment.value += quantity;
+        this.services.characterService.characterState.checkOverage();
       },
     },
     cabbage: {
@@ -319,12 +307,12 @@ export class ItemRepoService {
       useDescription: 'Fills your belly and helps you be healthy.',
       useConsumes: true,
       use: (quantity = 1) => {
-        this.characterService.characterState.status.nourishment.value += quantity;
+        this.services.characterService.characterState.status.nourishment.value += quantity;
         if (Math.random() < 0.01) {
-          this.characterService.characterState.healthBonusFood += quantity;
-          this.characterService.characterState.status.health.value += quantity;
+          this.services.characterService.characterState.healthBonusFood += quantity;
+          this.services.characterService.characterState.status.health.value += quantity;
         }
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.checkOverage();
       },
     },
     beans: {
@@ -337,17 +325,17 @@ export class ItemRepoService {
       useDescription: 'Fills your belly and helps you be healthy and hardy.',
       useConsumes: true,
       use: (quantity = 1) => {
-        this.characterService.characterState.status.nourishment.value += quantity;
+        this.services.characterService.characterState.status.nourishment.value += quantity;
         if (Math.random() < 0.02) {
-          this.characterService.characterState.healthBonusFood += quantity;
-          this.characterService.characterState.status.health.value += quantity;
-          if (this.characterService.characterState.foodLifespan + quantity <= (365 * 5)) {
-            this.characterService.characterState.foodLifespan += quantity;
-          } else if (this.characterService.characterState.foodLifespan < (365 * 5)) {
-            this.characterService.characterState.foodLifespan = 365 * 5;
+          this.services.characterService.characterState.healthBonusFood += quantity;
+          this.services.characterService.characterState.status.health.value += quantity;
+          if (this.services.characterService.characterState.foodLifespan + quantity <= (365 * 5)) {
+            this.services.characterService.characterState.foodLifespan += quantity;
+          } else if (this.services.characterService.characterState.foodLifespan < (365 * 5)) {
+            this.services.characterService.characterState.foodLifespan = 365 * 5;
           }
         }
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.checkOverage();
       },
     },
     broccoli: {
@@ -360,17 +348,17 @@ export class ItemRepoService {
       useDescription: 'Fills your belly and helps you be healthy and hardy.',
       useConsumes: true,
       use: (quantity = 1) => {
-        this.characterService.characterState.status.nourishment.value += quantity;
+        this.services.characterService.characterState.status.nourishment.value += quantity;
         if (Math.random() < 0.05) {
-          this.characterService.characterState.healthBonusFood += quantity;
-          this.characterService.characterState.status.health.value += quantity;
-          if (this.characterService.characterState.foodLifespan + quantity <= (365 * 10)) {
-            this.characterService.characterState.foodLifespan += quantity;
-          } else if (this.characterService.characterState.foodLifespan < (365 * 10)) {
-            this.characterService.characterState.foodLifespan = 365 * 10;
+          this.services.characterService.characterState.healthBonusFood += quantity;
+          this.services.characterService.characterState.status.health.value += quantity;
+          if (this.services.characterService.characterState.foodLifespan + quantity <= (365 * 10)) {
+            this.services.characterService.characterState.foodLifespan += quantity;
+          } else if (this.services.characterService.characterState.foodLifespan < (365 * 10)) {
+            this.services.characterService.characterState.foodLifespan = 365 * 10;
           }
         }
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.checkOverage();
       },
     },
     calabash: {
@@ -383,17 +371,17 @@ export class ItemRepoService {
       useDescription: 'Fills your belly and helps you be healthy and hardy.',
       useConsumes: true,
       use: (quantity = 1) => {
-        this.characterService.characterState.status.nourishment.value += quantity;
+        this.services.characterService.characterState.status.nourishment.value += quantity;
         if (Math.random() < 0.08) {
-          this.characterService.characterState.healthBonusFood += quantity;
-          this.characterService.characterState.status.health.value += quantity;
-          if (this.characterService.characterState.foodLifespan + quantity <= (365 * 15)) {
-            this.characterService.characterState.foodLifespan += quantity;
-          } else if (this.characterService.characterState.foodLifespan < (365 * 15)) {
-            this.characterService.characterState.foodLifespan = 365 * 15;
+          this.services.characterService.characterState.healthBonusFood += quantity;
+          this.services.characterService.characterState.status.health.value += quantity;
+          if (this.services.characterService.characterState.foodLifespan + quantity <= (365 * 15)) {
+            this.services.characterService.characterState.foodLifespan += quantity;
+          } else if (this.services.characterService.characterState.foodLifespan < (365 * 15)) {
+            this.services.characterService.characterState.foodLifespan = 365 * 15;
           }
         }
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.checkOverage();
       },
     },
     taro: {
@@ -406,17 +394,17 @@ export class ItemRepoService {
       useDescription: 'Fills your belly and helps you be healthy and hardy.',
       useConsumes: true,
       use: (quantity = 1) => {
-        this.characterService.characterState.status.nourishment.value += quantity;
+        this.services.characterService.characterState.status.nourishment.value += quantity;
         if (Math.random() < 0.1) {
-          this.characterService.characterState.healthBonusFood += quantity;
-          this.characterService.characterState.status.health.value += quantity;
-          if (this.characterService.characterState.foodLifespan + quantity <= (365 * 20)) {
-            this.characterService.characterState.foodLifespan += quantity;
-          } else if (this.characterService.characterState.foodLifespan < (365 * 20)) {
-            this.characterService.characterState.foodLifespan = 365 * 20;
+          this.services.characterService.characterState.healthBonusFood += quantity;
+          this.services.characterService.characterState.status.health.value += quantity;
+          if (this.services.characterService.characterState.foodLifespan + quantity <= (365 * 20)) {
+            this.services.characterService.characterState.foodLifespan += quantity;
+          } else if (this.services.characterService.characterState.foodLifespan < (365 * 20)) {
+            this.services.characterService.characterState.foodLifespan = 365 * 20;
           }
         }
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.checkOverage();
       },
     },
     pear: {
@@ -429,17 +417,17 @@ export class ItemRepoService {
       useDescription: 'Fills your belly and helps you be healthy and hardy.',
       useConsumes: true,
       use: (quantity = 1) => {
-        this.characterService.characterState.status.nourishment.value += quantity;
+        this.services.characterService.characterState.status.nourishment.value += quantity;
         if (Math.random() < 0.12) {
-          this.characterService.characterState.healthBonusFood += quantity;
-          this.characterService.characterState.status.health.value += quantity;
-          if (this.characterService.characterState.foodLifespan + quantity <= (365 * 25)) {
-            this.characterService.characterState.foodLifespan += quantity;
-          } else if (this.characterService.characterState.foodLifespan < (365 * 25)) {
-            this.characterService.characterState.foodLifespan = 365 * 25;
+          this.services.characterService.characterState.healthBonusFood += quantity;
+          this.services.characterService.characterState.status.health.value += quantity;
+          if (this.services.characterService.characterState.foodLifespan + quantity <= (365 * 25)) {
+            this.services.characterService.characterState.foodLifespan += quantity;
+          } else if (this.services.characterService.characterState.foodLifespan < (365 * 25)) {
+            this.services.characterService.characterState.foodLifespan = 365 * 25;
           }
         }
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.checkOverage();
       },
     },
     melon: {
@@ -452,17 +440,17 @@ export class ItemRepoService {
       useDescription: 'Fills your belly and helps you be healthy and hardy.',
       useConsumes: true,
       use: (quantity = 1) => {
-        this.characterService.characterState.status.nourishment.value += quantity;
+        this.services.characterService.characterState.status.nourishment.value += quantity;
         if (Math.random() < 0.15) {
-          this.characterService.characterState.healthBonusFood += quantity;
-          this.characterService.characterState.status.health.value += quantity;
-          if (this.characterService.characterState.foodLifespan + quantity <= (365 * 30)) {
-            this.characterService.characterState.foodLifespan += quantity;
-          } else if (this.characterService.characterState.foodLifespan < (365 * 30)) {
-            this.characterService.characterState.foodLifespan = 365 * 30;
+          this.services.characterService.characterState.healthBonusFood += quantity;
+          this.services.characterService.characterState.status.health.value += quantity;
+          if (this.services.characterService.characterState.foodLifespan + quantity <= (365 * 30)) {
+            this.services.characterService.characterState.foodLifespan += quantity;
+          } else if (this.services.characterService.characterState.foodLifespan < (365 * 30)) {
+            this.services.characterService.characterState.foodLifespan = 365 * 30;
           }
         }
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.checkOverage();
       },
     },
     plum: {
@@ -475,17 +463,17 @@ export class ItemRepoService {
       useDescription: 'Fills your belly and helps you be healthy and hardy.',
       useConsumes: true,
       use: (quantity = 1) => {
-        this.characterService.characterState.status.nourishment.value += quantity;
+        this.services.characterService.characterState.status.nourishment.value += quantity;
         if (Math.random() < 0.18) {
-          this.characterService.characterState.healthBonusFood += quantity;
-          this.characterService.characterState.status.health.value += quantity;
-          if (this.characterService.characterState.foodLifespan + quantity <= (365 * 35)) {
-            this.characterService.characterState.foodLifespan += quantity;
-          } else if (this.characterService.characterState.foodLifespan < (365 * 35)) {
-            this.characterService.characterState.foodLifespan = 365 * 35;
+          this.services.characterService.characterState.healthBonusFood += quantity;
+          this.services.characterService.characterState.status.health.value += quantity;
+          if (this.services.characterService.characterState.foodLifespan + quantity <= (365 * 35)) {
+            this.services.characterService.characterState.foodLifespan += quantity;
+          } else if (this.services.characterService.characterState.foodLifespan < (365 * 35)) {
+            this.services.characterService.characterState.foodLifespan = 365 * 35;
           }
         }
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.checkOverage();
       },
     },
     apricot: {
@@ -498,17 +486,17 @@ export class ItemRepoService {
       useDescription: 'Fills your belly and helps you be healthy and hardy.',
       useConsumes: true,
       use: (quantity = 1) => {
-        this.characterService.characterState.status.nourishment.value += quantity;
+        this.services.characterService.characterState.status.nourishment.value += quantity;
         if (Math.random() < 0.20) {
-          this.characterService.characterState.healthBonusFood += quantity;
-          this.characterService.characterState.status.health.value += quantity;
-          if (this.characterService.characterState.foodLifespan + quantity <= (365 * 40)) {
-            this.characterService.characterState.foodLifespan += quantity;
-          } else if (this.characterService.characterState.foodLifespan < (365 * 40)) {
-            this.characterService.characterState.foodLifespan = 365 * 40;
+          this.services.characterService.characterState.healthBonusFood += quantity;
+          this.services.characterService.characterState.status.health.value += quantity;
+          if (this.services.characterService.characterState.foodLifespan + quantity <= (365 * 40)) {
+            this.services.characterService.characterState.foodLifespan += quantity;
+          } else if (this.services.characterService.characterState.foodLifespan < (365 * 40)) {
+            this.services.characterService.characterState.foodLifespan = 365 * 40;
           }
         }
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.checkOverage();
       },
     },
     peach: {
@@ -521,17 +509,17 @@ export class ItemRepoService {
       useDescription: 'Fills your belly and can even lead to a long life.',
       useConsumes: true,
       use: (quantity = 1) => {
-        this.characterService.characterState.status.nourishment.value += quantity;
+        this.services.characterService.characterState.status.nourishment.value += quantity;
         if (Math.random() < 0.22) {
-          this.characterService.characterState.healthBonusFood += quantity;
-          this.characterService.characterState.status.health.value += quantity * 2;
-          if (this.characterService.characterState.foodLifespan + quantity <= (365 * 72)) {
-            this.characterService.characterState.foodLifespan += quantity;
-          } else if (this.characterService.characterState.foodLifespan < (365 * 72)) {
-            this.characterService.characterState.foodLifespan = 365 * 72;
+          this.services.characterService.characterState.healthBonusFood += quantity;
+          this.services.characterService.characterState.status.health.value += quantity * 2;
+          if (this.services.characterService.characterState.foodLifespan + quantity <= (365 * 72)) {
+            this.services.characterService.characterState.foodLifespan += quantity;
+          } else if (this.services.characterService.characterState.foodLifespan < (365 * 72)) {
+            this.services.characterService.characterState.foodLifespan = 365 * 72;
           }
         }
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.checkOverage();
       },
     },
     divinePeach: {
@@ -544,19 +532,19 @@ export class ItemRepoService {
       useDescription: 'Sates your immortal hunger.',
       useConsumes: true,
       use: (quantity = 1) => {
-        this.characterService.characterState.status.nourishment.max += quantity;
-        this.characterService.characterState.status.nourishment.value += quantity;
-        this.characterService.characterState.healthBonusFood += quantity * 2;
-        this.characterService.characterState.status.health.value += quantity * 20;
-        this.characterService.characterState.status.stamina.value += quantity * 2;
-        this.characterService.characterState.status.stamina.max += quantity * 2;
-        this.characterService.characterState.status.mana.value += quantity;
-        if (this.characterService.characterState.foodLifespan + quantity <= (365 * 720)) {
-          this.characterService.characterState.foodLifespan += quantity;
-        } else if (this.characterService.characterState.foodLifespan < (365 * 720)) {
-          this.characterService.characterState.foodLifespan = 365 * 720;
+        this.services.characterService.characterState.status.nourishment.max += quantity;
+        this.services.characterService.characterState.status.nourishment.value += quantity;
+        this.services.characterService.characterState.healthBonusFood += quantity * 2;
+        this.services.characterService.characterState.status.health.value += quantity * 20;
+        this.services.characterService.characterState.status.stamina.value += quantity * 2;
+        this.services.characterService.characterState.status.stamina.max += quantity * 2;
+        this.services.characterService.characterState.status.mana.value += quantity;
+        if (this.services.characterService.characterState.foodLifespan + quantity <= (365 * 720)) {
+          this.services.characterService.characterState.foodLifespan += quantity;
+        } else if (this.services.characterService.characterState.foodLifespan < (365 * 720)) {
+          this.services.characterService.characterState.foodLifespan = 365 * 720;
         }
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.checkOverage();
       },
     },
     meat: {
@@ -569,11 +557,11 @@ export class ItemRepoService {
       useDescription: 'Fills your belly. Can also improve your health and stamina.',
       useConsumes: true,
       use: (quantity = 1) => {
-        this.characterService.characterState.status.nourishment.value += quantity * 2;
-        this.characterService.characterState.healthBonusFood += quantity;
-        this.characterService.characterState.status.health.value += quantity * 10;
-        this.characterService.characterState.status.stamina.max += quantity;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.nourishment.value += quantity * 2;
+        this.services.characterService.characterState.healthBonusFood += quantity;
+        this.services.characterService.characterState.status.health.value += quantity * 10;
+        this.services.characterService.characterState.status.stamina.max += quantity;
+        this.services.characterService.characterState.checkOverage();
       },
     },
     spiritMeat: {
@@ -586,11 +574,11 @@ export class ItemRepoService {
       useDescription: 'Fills your belly. Can also improve your health and stamina.',
       useConsumes: true,
       use: (quantity = 1) => {
-        this.characterService.characterState.status.nourishment.value += quantity * 2;
-        this.characterService.characterState.healthBonusFood += quantity;
-        this.characterService.characterState.status.health.value += quantity * 20;
-        this.characterService.characterState.status.stamina.max += quantity;
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.status.nourishment.value += quantity * 2;
+        this.services.characterService.characterState.healthBonusFood += quantity;
+        this.services.characterService.characterState.status.health.value += quantity * 20;
+        this.services.characterService.characterState.status.stamina.max += quantity;
+        this.services.characterService.characterState.checkOverage();
       },
     },
     carp: {
@@ -603,12 +591,12 @@ export class ItemRepoService {
       useDescription: 'Fills your belly. Might also improve your health and stamina.',
       useConsumes: true,
       use: (quantity = 1) => {
-        this.characterService.characterState.status.nourishment.value += quantity;
+        this.services.characterService.characterState.status.nourishment.value += quantity;
         if (Math.random() < 0.1) {
-          this.characterService.characterState.healthBonusFood += quantity;
-          this.characterService.characterState.status.stamina.max += quantity;
+          this.services.characterService.characterState.healthBonusFood += quantity;
+          this.services.characterService.characterState.status.stamina.max += quantity;
         }
-        this.characterService.characterState.checkOverage();
+        this.services.characterService.characterState.checkOverage();
       },
     },
     hide: {
@@ -1140,23 +1128,17 @@ export class ItemRepoService {
       useDescription: 'Become immortal and win the game.',
       useConsumes: true,
       use: () => {
-        if (!this.impossibleTaskService) {
-          this.impossibleTaskService = this.injector.get(ImpossibleTaskService);
-        }
-        this.impossibleTaskService.taskProgress[ImpossibleTaskType.OvercomeDeath].progress++;
-        this.impossibleTaskService.activeTaskIndex = ImpossibleTaskType.OvercomeDeath; // just in case. Don't want this use to fail.
-        this.impossibleTaskService.checkCompletion();
-        if (this.impossibleTaskService.taskProgress[ImpossibleTaskType.OvercomeDeath].complete) {
-          this.logService.addLogMessage("YOU HAVE ACHIEVED IMMORTALITY! YOU WILL LIVE FOREVER!", "INJURY", 'STORY');
-          if (!this.gameStateService) {
-            this.gameStateService = this.injector.get(GameStateService);
+        this.services.impossibleTaskService.taskProgress[ImpossibleTaskType.OvercomeDeath].progress++;
+        this.services.impossibleTaskService.activeTaskIndex = ImpossibleTaskType.OvercomeDeath; // just in case. Don't want this use to fail.
+        this.services.impossibleTaskService.checkCompletion();
+        if (this.services.impossibleTaskService.taskProgress[ImpossibleTaskType.OvercomeDeath].complete) {
+          this.services.logService.addLogMessage("YOU HAVE ACHIEVED IMMORTALITY! YOU WILL LIVE FOREVER!", "INJURY", 'STORY');
+          if (this.services.gameStateService.easyModeEver) {
+            this.services.logService.addLogMessage("Good work, even if you did take the easy path. For more of a challenge, you could reset and try without using the easy game mode.", "STANDARD", 'STORY');
           }
-          if (this.gameStateService.easyModeEver) {
-            this.logService.addLogMessage("Good work, even if you did take the easy path. For more of a challenge, you could reset and try without using the easy game mode.", "STANDARD", 'STORY');
-          }
-          this.logService.addLogMessage("You started your journey on " + new Date(this.gameStateService.gameStartTimestamp).toDateString() + " and succeeded in your quest on " + new Date().toDateString() + ".", "STANDARD", 'STORY');
-          this.logService.addLogMessage("You took " + this.mainLoopService.totalTicks + " days over " + this.characterService.characterState.totalLives + " lifetimes to overcome death.", "STANDARD", 'STORY');
-          this.characterService.characterState.immortal = true;
+          this.services.logService.addLogMessage("You started your journey on " + new Date(this.services.gameStateService.gameStartTimestamp).toDateString() + " and succeeded in your quest on " + new Date().toDateString() + ".", "STANDARD", 'STORY');
+          this.services.logService.addLogMessage("You took " + this.services.mainLoopService.totalTicks + " days over " + this.services.characterService.characterState.totalLives + " lifetimes to overcome death.", "STANDARD", 'STORY');
+          this.services.characterService.characterState.immortal = true;
         }
       },
     },
@@ -1170,25 +1152,13 @@ export class ItemRepoService {
       useDescription: 'Become a god and win the game (again).',
       useConsumes: true,
       use: () => {
-        this.logService.addLogMessage("YOU HAVE ACHIEVED GODHOOD! YOU WILL RULE OVER THE UNIVERSE FOREVER!", "INJURY", 'STORY');
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
-        }
-        this.hellService.inHell = false;
-        if (!this.gameStateService) {
-          this.gameStateService = this.injector.get(GameStateService);
-        }
-        if (!this.activityService) {
-          this.activityService = this.injector.get(ActivityService);
-        }
-        if (!this.battleService) {
-          this.battleService = this.injector.get(BattleService);
-        }
-        this.logService.addLogMessage("You started your journey on " + new Date(this.gameStateService.gameStartTimestamp).toDateString() + " and achieved godhood on " + new Date().toDateString() + ".", "STANDARD", 'STORY');
-        this.logService.addLogMessage("You took " + this.mainLoopService.totalTicks + " days over " + this.characterService.characterState.totalLives + " lifetimes to claim your throne on Mount Penglai.", "STANDARD", 'STORY');
-        this.characterService.characterState.god = true;
-        this.battleService.troubleKills = 0;
-        this.activityService.reloadActivities();
+        this.services.logService.addLogMessage("YOU HAVE ACHIEVED GODHOOD! YOU WILL RULE OVER THE UNIVERSE FOREVER!", "INJURY", 'STORY');
+        this.services.hellService.inHell = false;
+        this.services.logService.addLogMessage("You started your journey on " + new Date(this.services.gameStateService.gameStartTimestamp).toDateString() + " and achieved godhood on " + new Date().toDateString() + ".", "STANDARD", 'STORY');
+        this.services.logService.addLogMessage("You took " + this.services.mainLoopService.totalTicks + " days over " + this.services.characterService.characterState.totalLives + " lifetimes to claim your throne on Mount Penglai.", "STANDARD", 'STORY');
+        this.services.characterService.characterState.god = true;
+        this.services.battleService.troubleKills = 0;
+        this.services.activityService.reloadActivities();
       },
     },
     fingers: {
@@ -1250,17 +1220,11 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.TongueRipping)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.TongueRipping);
         }
-        if (!this.followerService) {
-          this.followerService = this.injector.get(FollowersService);
-        }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.TongueRipping)) {
-          this.hellService.completedHellBosses.push(HellLevel.TongueRipping);
-        }
-        this.logService.addLogMessage("The Crown of Tongue Rippers settles onto your head, then sinks in to become a part of your very soul. You feel that your words carry a new power that can inspire a new kind of follower to worship you as the god you are becoming. Perhaps a trip back to the mortal realm through reincarnation might we worthwhile.", "STANDARD", 'STORY');
-        this.followerService.unlockJob("prophet");
+        this.services.logService.addLogMessage("The Crown of Tongue Rippers settles onto your head, then sinks in to become a part of your very soul. You feel that your words carry a new power that can inspire a new kind of follower to worship you as the god you are becoming. Perhaps a trip back to the mortal realm through reincarnation might we worthwhile.", "STANDARD", 'STORY');
+        this.services.followerService.unlockJob("prophet");
       },
     },
     hellCrownScissors: {
@@ -1273,18 +1237,12 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.Scissors)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.Scissors);
         }
-        if (!this.followerService) {
-          this.followerService = this.injector.get(FollowersService);
-        }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.Scissors)) {
-          this.hellService.completedHellBosses.push(HellLevel.Scissors);
-        }
-        this.logService.addLogMessage("The Crown of Scissors settles onto your head, then sinks in to become a part of your very soul. You feel a deeper appreciation for marriage and family, and your followers sense it.", "STANDARD", 'STORY');
-        this.logService.addLogMessage("From now on, each follower will train a child to replace themselves in your service when they pass away.", "STANDARD", 'STORY');
-        this.followerService.autoReplaceUnlocked = true;
+        this.services.logService.addLogMessage("The Crown of Scissors settles onto your head, then sinks in to become a part of your very soul. You feel a deeper appreciation for marriage and family, and your followers sense it.", "STANDARD", 'STORY');
+        this.services.logService.addLogMessage("From now on, each follower will train a child to replace themselves in your service when they pass away.", "STANDARD", 'STORY');
+        this.services.followerService.autoReplaceUnlocked = true;
       },
     },
     hellCrownTreesOfKnives: {
@@ -1297,17 +1255,11 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.TreesOfKnives)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.TreesOfKnives);
         }
-        if (!this.followerService) {
-          this.followerService = this.injector.get(FollowersService);
-        }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.TreesOfKnives)) {
-          this.hellService.completedHellBosses.push(HellLevel.TreesOfKnives);
-        }
-        this.logService.addLogMessage("The Crown of Knives settles onto your head, then sinks in to become a part of your very soul. You can recruit a new follower specialized in honoring ancestors.", "STANDARD", 'STORY');
-        this.followerService.unlockJob("moneyBurner");
+        this.services.logService.addLogMessage("The Crown of Knives settles onto your head, then sinks in to become a part of your very soul. You can recruit a new follower specialized in honoring ancestors.", "STANDARD", 'STORY');
+        this.services.followerService.unlockJob("moneyBurner");
       },
     },
     hellCrownMirrors: {
@@ -1320,21 +1272,12 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.Mirrors)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.Mirrors);
         }
-        if (!this.followerService) {
-          this.followerService = this.injector.get(FollowersService);
-        }
-        if (!this.activityService) {
-          this.activityService = this.injector.get(ActivityService);
-        }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.Mirrors)) {
-          this.hellService.completedHellBosses.push(HellLevel.Mirrors);
-        }
-        this.logService.addLogMessage("The Crown of Mirrors settles onto your head, then sinks in to become a part of your very soul. A deep understanding of combat based on your many battles with yourself reveals itself in a moment of enlightenment.", "STANDARD", 'STORY');
-        this.characterService.characterState.attributes.combatMastery.value += 1;
-        this.activityService.CombatTraining.unlocked = true;
+        this.services.logService.addLogMessage("The Crown of Mirrors settles onto your head, then sinks in to become a part of your very soul. A deep understanding of combat based on your many battles with yourself reveals itself in a moment of enlightenment.", "STANDARD", 'STORY');
+        this.services.characterService.characterState.attributes.combatMastery.value += 1;
+        this.services.activityService.CombatTraining.unlocked = true;
       },
     },
     hellCrownSteamers: {
@@ -1347,17 +1290,11 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.Steamers)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.Steamers);
         }
-        if (!this.battleService) {
-          this.battleService = this.injector.get(BattleService);
-        }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.Steamers)) {
-          this.hellService.completedHellBosses.push(HellLevel.Steamers);
-        }
-        this.logService.addLogMessage("The Crown of Steam settles onto your head, then sinks in to become a part of your very soul. You learn to harness the intense heat of the Hell of Steamers in a powerful magical blast.", "STANDARD", 'STORY');
-        this.battleService.pyroclasmUnlocked = true;
+        this.services.logService.addLogMessage("The Crown of Steam settles onto your head, then sinks in to become a part of your very soul. You learn to harness the intense heat of the Hell of Steamers in a powerful magical blast.", "STANDARD", 'STORY');
+        this.services.battleService.pyroclasmUnlocked = true;
       },
     },
     hellCrownPillars: {
@@ -1370,17 +1307,11 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.CopperPillars)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.CopperPillars);
         }
-        if (!this.battleService) {
-          this.battleService = this.injector.get(BattleService);
-        }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.CopperPillars)) {
-          this.hellService.completedHellBosses.push(HellLevel.CopperPillars);
-        }
-        this.logService.addLogMessage("The Crown of Pillars settles onto your head, then sinks in to become a part of your very soul. You can now summon a massive metal fist with each of your combat strikes.", "STANDARD", 'STORY');
-        this.battleService.metalFistUnlocked = true;
+        this.services.logService.addLogMessage("The Crown of Pillars settles onto your head, then sinks in to become a part of your very soul. You can now summon a massive metal fist with each of your combat strikes.", "STANDARD", 'STORY');
+        this.services.battleService.metalFistUnlocked = true;
       },
     },
     hellCrownMountainOfKnives: {
@@ -1393,14 +1324,11 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.MountainOfKnives)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.MountainOfKnives);
         }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.MountainOfKnives)) {
-          this.hellService.completedHellBosses.push(HellLevel.MountainOfKnives);
-        }
-        this.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. Having balanced your karmic debt, you begin to see the balance in all the world around you.", "STANDARD", 'STORY');
-        this.characterService.characterState.yinYangUnlocked = true;
+        this.services.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. Having balanced your karmic debt, you begin to see the balance in all the world around you.", "STANDARD", 'STORY');
+        this.services.characterService.characterState.yinYangUnlocked = true;
       },
     },
     hellCrownMountainOfIce: {
@@ -1413,17 +1341,11 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.MountainOfIce)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.MountainOfIce);
         }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.MountainOfIce)) {
-          this.hellService.completedHellBosses.push(HellLevel.MountainOfIce);
-        }
-        if (!this.battleService) {
-          this.battleService = this.injector.get(BattleService);
-        }
-        this.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. The deep freezing from the mountain has given you a new idea for how to defend yourself.", "STANDARD", 'STORY');
-        this.battleService.iceShieldUnlocked = true;
+        this.services.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. The deep freezing from the mountain has given you a new idea for how to defend yourself.", "STANDARD", 'STORY');
+        this.services.battleService.iceShieldUnlocked = true;
       },
     },
     hellCrownCauldronsOfOil: {
@@ -1436,14 +1358,11 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.CauldronsOfOil)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.CauldronsOfOil);
         }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.CauldronsOfOil)) {
-          this.hellService.completedHellBosses.push(HellLevel.CauldronsOfOil);
-        }
-        this.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. A new resolve awakens in you to protect the defenseless from those that would abuse them.", "STANDARD", 'STORY');
-        this.characterService.characterState.righteousWrathUnlocked = true;
+        this.services.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. A new resolve awakens in you to protect the defenseless from those that would abuse them.", "STANDARD", 'STORY');
+        this.services.characterService.characterState.righteousWrathUnlocked = true;
       },
     },
     hellCrownCattlePit: {
@@ -1456,17 +1375,11 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.CattlePit)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.CattlePit);
         }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.CattlePit)) {
-          this.hellService.completedHellBosses.push(HellLevel.CattlePit);
-        }
-        if (!this.followerService) {
-          this.followerService = this.injector.get(FollowersService);
-        }
-        this.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. You find a new and deep connection to animals that you've never felt before.", "STANDARD", 'STORY');
-        this.followerService.unlockElementalPets();
+        this.services.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. You find a new and deep connection to animals that you've never felt before.", "STANDARD", 'STORY');
+        this.services.followerService.unlockElementalPets();
       },
     },
     hellCrownCrushingBoulder: {
@@ -1479,14 +1392,11 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.CrushingBoulder)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.CrushingBoulder);
         }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.CrushingBoulder)) {
-          this.hellService.completedHellBosses.push(HellLevel.CrushingBoulder);
-        }
-        this.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. Your muscles swell with new power.", "STANDARD", 'STORY');
-        this.characterService.characterState.bonusMuscles = true;
+        this.services.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. Your muscles swell with new power.", "STANDARD", 'STORY');
+        this.services.characterService.characterState.bonusMuscles = true;
       },
     },
     hellCrownMortarsAndPestles: {
@@ -1499,22 +1409,13 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.MortarsAndPestles)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.MortarsAndPestles);
         }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.MortarsAndPestles)) {
-          this.hellService.completedHellBosses.push(HellLevel.MortarsAndPestles);
-        }
-        if (!this.homeService) {
-          this.homeService = this.injector.get(HomeService);
-        }
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. You come to a deep appreciation of the value and importance of food.", "STANDARD", 'STORY');
-        this.homeService.hellFood = true;
-        this.inventoryService.divinePeachesUnlocked = true;
-        this.inventoryService.updateFarmFoodList();
+        this.services.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. You come to a deep appreciation of the value and importance of food.", "STANDARD", 'STORY');
+        this.services.homeService.hellFood = true;
+        this.services.inventoryService.divinePeachesUnlocked = true;
+        this.services.inventoryService.updateFarmFoodList();
 
       },
     },
@@ -1528,17 +1429,11 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.BloodPool)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.BloodPool);
         }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.BloodPool)) {
-          this.hellService.completedHellBosses.push(HellLevel.BloodPool);
-        }
-        if (!this.homeService) {
-          this.homeService = this.injector.get(HomeService);
-        }
-        this.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. Your bloodline becomes so powerful that the benefits of your ancestral home now apply even when you are no longer in the mortal realm.", "STANDARD", 'STORY');
-        this.homeService.hellHome = true;
+        this.services.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. Your bloodline becomes so powerful that the benefits of your ancestral home now apply even when you are no longer in the mortal realm.", "STANDARD", 'STORY');
+        this.services.homeService.hellHome = true;
       },
     },
     hellCrownWrongfulDead: {
@@ -1551,14 +1446,11 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.WrongfulDead)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.WrongfulDead);
         }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.WrongfulDead)) {
-          this.hellService.completedHellBosses.push(HellLevel.WrongfulDead);
-        }
-        this.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. Your mind suddenly expands with endless new possibilities.", "STANDARD", 'STORY');
-        this.characterService.characterState.bonusBrains = true;
+        this.services.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. Your mind suddenly expands with endless new possibilities.", "STANDARD", 'STORY');
+        this.services.characterService.characterState.bonusBrains = true;
       },
     },
     hellCrownDismemberment: {
@@ -1571,18 +1463,12 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.Dismemberment)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.Dismemberment);
         }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.Dismemberment)) {
-          this.hellService.completedHellBosses.push(HellLevel.Dismemberment);
-        }
-        if (!this.activityService) {
-          this.activityService = this.injector.get(ActivityService);
-        }
-        this.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. If you are spiritual enough, you can now purify gems to infuse new effects into your weapons.", "STANDARD", 'STORY');
-        this.activityService.purifyGemsUnlocked = true;
-        this.activityService.reloadActivities();
+        this.services.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. If you are spiritual enough, you can now purify gems to infuse new effects into your weapons.", "STANDARD", 'STORY');
+        this.services.activityService.purifyGemsUnlocked = true;
+        this.services.activityService.reloadActivities();
       },
     },
     hellCrownFireMountain: {
@@ -1595,17 +1481,11 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.MountainOfFire)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.MountainOfFire);
         }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.MountainOfFire)) {
-          this.hellService.completedHellBosses.push(HellLevel.MountainOfFire);
-        }
-        if (!this.battleService) {
-          this.battleService = this.injector.get(BattleService);
-        }
-        this.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. The intense heat of the volcano has strengthened your inner fire, allowing you to form a barrier to protect you and harm your enemies.", "STANDARD", 'STORY');
-        this.battleService.fireShieldUnlocked = true;
+        this.services.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. The intense heat of the volcano has strengthened your inner fire, allowing you to form a barrier to protect you and harm your enemies.", "STANDARD", 'STORY');
+        this.services.battleService.fireShieldUnlocked = true;
       },
     },
     hellCrownMills: {
@@ -1618,14 +1498,11 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.Mills)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.Mills);
         }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.Mills)) {
-          this.hellService.completedHellBosses.push(HellLevel.Mills);
-        }
-        this.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. The intense pressure of the mill has strengthened your skin and bones allowing you to increase your total health dramatically.", "STANDARD", 'STORY');
-        this.characterService.characterState.bonusHealth = true;
+        this.services.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. The intense pressure of the mill has strengthened your skin and bones allowing you to increase your total health dramatically.", "STANDARD", 'STORY');
+        this.services.characterService.characterState.bonusHealth = true;
       },
     },
     hellCrownSaws: {
@@ -1638,18 +1515,12 @@ export class ItemRepoService {
       useDescription: '',
       useConsumes: true,
       use: () => {
-        if (!this.hellService) {
-          this.hellService = this.injector.get(HellService);
-        }
-        if (!this.hellService.completedHellBosses.includes(HellLevel.Saws)) {
-          this.hellService.completedHellBosses.push(HellLevel.Saws);
-        }
-        if (!this.followerService) {
-          this.followerService = this.injector.get(FollowersService);
+        if (!this.services.hellService.completedHellBosses.includes(HellLevel.Saws)) {
+          this.services.hellService.completedHellBosses.push(HellLevel.Saws);
         }
 
-        this.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. You can now recruit followers that put their swindling and cheating to good use.", "STANDARD", 'STORY');
-        this.followerService.unlockJob("banker");
+        this.services.logService.addLogMessage("The crown settles onto your head, then sinks in to become a part of your very soul. You can now recruit followers that put their swindling and cheating to good use.", "STANDARD", 'STORY');
+        this.services.followerService.unlockJob("banker");
       },
     },
     fastPlayManual: {
@@ -1662,12 +1533,12 @@ export class ItemRepoService {
       useDescription: "Permanently unlock fast game speed.",
       useConsumes: true,
       use: () => {
-        this.mainLoopService.unlockFastSpeed = true;
-        this.mainLoopService.topDivider = this.mainLoopService.topDivider > 5 ? 5 : this.mainLoopService.topDivider;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.mainLoopService.unlockFastSpeed = true;
+        this.services.mainLoopService.topDivider = this.services.mainLoopService.topDivider > 5 ? 5 : this.services.mainLoopService.topDivider;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        return this.mainLoopService.unlockFastSpeed;
+        return this.services.mainLoopService.unlockFastSpeed;
       }
     },
     fasterPlayManual: {
@@ -1680,12 +1551,12 @@ export class ItemRepoService {
       useDescription: "Permanently unlock faster game speed.",
       useConsumes: true,
       use: () => {
-        this.mainLoopService.unlockFasterSpeed = true;
-        this.mainLoopService.topDivider = this.mainLoopService.topDivider > 2 ? 2 : this.mainLoopService.topDivider;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.mainLoopService.unlockFasterSpeed = true;
+        this.services.mainLoopService.topDivider = this.services.mainLoopService.topDivider > 2 ? 2 : this.services.mainLoopService.topDivider;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        return this.mainLoopService.unlockFasterSpeed;
+        return this.services.mainLoopService.unlockFasterSpeed;
       }
     },
     fastestPlayManual: {
@@ -1698,12 +1569,12 @@ export class ItemRepoService {
       useDescription: "Permanently unlock fastest game speed.",
       useConsumes: true,
       use: () => {
-        this.mainLoopService.unlockFastestSpeed = true;
-        this.mainLoopService.topDivider = 1;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.mainLoopService.unlockFastestSpeed = true;
+        this.services.mainLoopService.topDivider = 1;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        return this.mainLoopService.unlockFastestSpeed;
+        return this.services.mainLoopService.unlockFastestSpeed;
       }
     },
     restartActivityManual: {
@@ -1716,19 +1587,11 @@ export class ItemRepoService {
       useDescription: "Permanently unlock preserving activity plans across reincarnations.",
       useConsumes: true,
       use: () => {
-        // check if actvityService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.activityService) {
-          this.activityService = this.injector.get(ActivityService);
-        }
-        this.activityService.autoRestart = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.activityService.autoRestart = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if actvityService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.activityService) {
-          this.activityService = this.injector.get(ActivityService);
-        }
-        return this.activityService?.autoRestart;
+        return this.services.activityService?.autoRestart;
       }
     },
     autoSellManual: {
@@ -1741,19 +1604,11 @@ export class ItemRepoService {
       useDescription: "Permanently unlock auto-sell button in the inventory panel.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.autoSellUnlocked = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.inventoryService.autoSellUnlocked = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.autoSellUnlocked;
+        return this.services.inventoryService.autoSellUnlocked;
       }
     },
     autoUseManual: {
@@ -1766,19 +1621,11 @@ export class ItemRepoService {
       useDescription: "Permanently unlock auto-use button in the inventory panel.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.autoUseUnlocked = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.inventoryService.autoUseUnlocked = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.autoUseUnlocked;
+        return this.services.inventoryService.autoUseUnlocked;
       }
     },
     autoBalanceManual: {
@@ -1791,19 +1638,11 @@ export class ItemRepoService {
       useDescription: "Permanently unlock auto-balance button in the inventory panel.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.autoBalanceUnlocked = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.inventoryService.autoBalanceUnlocked = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.autoBalanceUnlocked;
+        return this.services.inventoryService.autoBalanceUnlocked;
       }
     },
     autoBuyLandManual: {
@@ -1816,17 +1655,11 @@ export class ItemRepoService {
       useDescription: "Permanently unlock automatic land purchasing.",
       useConsumes: true,
       use: () => {
-        if (!this.homeService) {
-          this.homeService = this.injector.get(HomeService);
-        }
-        this.homeService.autoBuyLandUnlocked = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.homeService.autoBuyLandUnlocked = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        if (!this.homeService) {
-          this.homeService = this.injector.get(HomeService);
-        }
-        return this.homeService.autoBuyLandUnlocked;
+        return this.services.homeService.autoBuyLandUnlocked;
       }
     },
     autoBuyHomeManual: {
@@ -1839,17 +1672,11 @@ export class ItemRepoService {
       useDescription: "Permanently unlock automatic home upgrades.",
       useConsumes: true,
       use: () => {
-        if (!this.homeService) {
-          this.homeService = this.injector.get(HomeService);
-        }
-        this.homeService.autoBuyHomeUnlocked = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.homeService.autoBuyHomeUnlocked = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        if (!this.homeService) {
-          this.homeService = this.injector.get(HomeService);
-        }
-        return this.homeService.autoBuyHomeUnlocked;
+        return this.services.homeService.autoBuyHomeUnlocked;
       }
     },
     autoBuyFurnitureManual: {
@@ -1862,17 +1689,11 @@ export class ItemRepoService {
       useDescription: "Permanently unlock automatic purchasing for furniture.",
       useConsumes: true,
       use: () => {
-        if (!this.homeService) {
-          this.homeService = this.injector.get(HomeService);
-        }
-        this.homeService.autoBuyFurnitureUnlocked = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.homeService.autoBuyFurnitureUnlocked = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        if (!this.homeService) {
-          this.homeService = this.injector.get(HomeService);
-        }
-        return this.homeService.autoBuyFurnitureUnlocked;
+        return this.services.homeService.autoBuyFurnitureUnlocked;
       }
     },
     autoBuyerSettingsManual: {
@@ -1885,17 +1706,11 @@ export class ItemRepoService {
       useDescription: "Permanently unlock auto-buying customization",
       useConsumes: true,
       use: () => {
-        if (!this.autoBuyerService) {
-          this.autoBuyerService = this.injector.get(AutoBuyerService);
-        }
-        this.autoBuyerService.autoBuyerSettingsUnlocked = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.autoBuyerService.autoBuyerSettingsUnlocked = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        if (!this.autoBuyerService) {
-          this.autoBuyerService = this.injector.get(AutoBuyerService);
-        }
-        return this.autoBuyerService.autoBuyerSettingsUnlocked;
+        return this.services.autoBuyerService.autoBuyerSettingsUnlocked;
       }
     },
     autoFieldManual: {
@@ -1908,17 +1723,11 @@ export class ItemRepoService {
       useDescription: "Permanently unlock automatic field plowing.",
       useConsumes: true,
       use: () => {
-        if (!this.homeService) {
-          this.homeService = this.injector.get(HomeService);
-        }
-        this.homeService.autoFieldUnlocked = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.homeService.autoFieldUnlocked = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        if (!this.homeService) {
-          this.homeService = this.injector.get(HomeService);
-        }
-        return this.homeService.autoFieldUnlocked;
+        return this.services.homeService.autoFieldUnlocked;
       }
     },
     autoPotionManual: {
@@ -1931,24 +1740,16 @@ export class ItemRepoService {
       useDescription: "Permanently unlock auto-drinking all potions.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.autoPotionUnlocked = true;
-        for (let index = this.inventoryService.autoUseEntries.length - 1; index >= 0; index--) {
-          if (this.inventoryService.autoUseEntries[index].name.includes("Potion")) {
-            this.inventoryService.autoUseEntries.splice(index, 1);
+        this.services.inventoryService.autoPotionUnlocked = true;
+        for (let index = this.services.inventoryService.autoUseEntries.length - 1; index >= 0; index--) {
+          if (this.services.inventoryService.autoUseEntries[index].name.includes("Potion")) {
+            this.services.inventoryService.autoUseEntries.splice(index, 1);
           }
         }
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.autoPotionUnlocked;
+        return this.services.inventoryService.autoPotionUnlocked;
       }
     },
     autoPillManual: {
@@ -1961,24 +1762,16 @@ export class ItemRepoService {
       useDescription: "Permanently unlock auto-swallowing all pills.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.autoPillUnlocked = true;
-        for (let index = this.inventoryService.autoUseEntries.length - 1; index >= 0; index--) {
-          if (this.inventoryService.autoUseEntries[index].name.includes("Pill")) {
-            this.inventoryService.autoUseEntries.splice(index, 1);
+        this.services.inventoryService.autoPillUnlocked = true;
+        for (let index = this.services.inventoryService.autoUseEntries.length - 1; index >= 0; index--) {
+          if (this.services.inventoryService.autoUseEntries[index].name.includes("Pill")) {
+            this.services.inventoryService.autoUseEntries.splice(index, 1);
           }
         }
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.autoPillUnlocked;
+        return this.services.inventoryService.autoPillUnlocked;
       }
     },
     autoTroubleManual: {
@@ -1991,19 +1784,11 @@ export class ItemRepoService {
       useDescription: "Permanently unlock automatic trouble in the battle panel.",
       useConsumes: true,
       use: () => {
-        // check if battleService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.battleService) {
-          this.battleService = this.injector.get(BattleService);
-        }
-        this.battleService.autoTroubleUnlocked = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.battleService.autoTroubleUnlocked = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if battleService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.battleService) {
-          this.battleService = this.injector.get(BattleService);
-        }
-        return this.battleService?.autoTroubleUnlocked;
+        return this.services.battleService?.autoTroubleUnlocked;
       }
     },
     autoWeaponMergeManual: {
@@ -2016,19 +1801,11 @@ export class ItemRepoService {
       useDescription: "Permanently unlock automatic weapon merging in the inventory panel.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.autoWeaponMergeUnlocked = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.inventoryService.autoWeaponMergeUnlocked = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.autoWeaponMergeUnlocked;
+        return this.services.inventoryService.autoWeaponMergeUnlocked;
       }
     },
     autoArmorMergeManual: {
@@ -2041,19 +1818,11 @@ export class ItemRepoService {
       useDescription: "Permanently unlock automatic armor merging in the inventory panel.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.autoArmorMergeUnlocked = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.inventoryService.autoArmorMergeUnlocked = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.autoArmorMergeUnlocked;
+        return this.services.inventoryService.autoArmorMergeUnlocked;
       }
     },
     useSpiritGemManual: {
@@ -2066,21 +1835,13 @@ export class ItemRepoService {
       useDescription: "Permanently unlock including spirit gems when creating items.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.useSpiritGemUnlocked = true;
-        this.inventoryService.useSpiritGemWeapons = true;
-        this.inventoryService.useSpiritGemPotions = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.inventoryService.useSpiritGemUnlocked = true;
+        this.services.inventoryService.useSpiritGemWeapons = true;
+        this.services.inventoryService.useSpiritGemPotions = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.useSpiritGemUnlocked;
+        return this.services.inventoryService.useSpiritGemUnlocked;
       }
     },
     bestHerbsManual: {
@@ -2093,20 +1854,12 @@ export class ItemRepoService {
       useDescription: "Permanently unlock auto-selling lower grade herbs.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.autoSellOldHerbs = true;
-        this.inventoryService.autoSellOldHerbsEnabled = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.inventoryService.autoSellOldHerbs = true;
+        this.services.inventoryService.autoSellOldHerbsEnabled = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.autoSellOldHerbs;
+        return this.services.inventoryService.autoSellOldHerbs;
       }
     },
     bestWoodManual: {
@@ -2119,20 +1872,12 @@ export class ItemRepoService {
       useDescription: "Permanently unlock auto-selling lower grade logs.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.autoSellOldWood = true;
-        this.inventoryService.autoSellOldWoodEnabled = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.inventoryService.autoSellOldWood = true;
+        this.services.inventoryService.autoSellOldWoodEnabled = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.autoSellOldWood;
+        return this.services.inventoryService.autoSellOldWood;
       }
     },
     bestOreManual: {
@@ -2145,21 +1890,13 @@ export class ItemRepoService {
       useDescription: "Permanently unlock auto-selling lower grade ores and bars.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.autoSellOldOre = true;
-        this.inventoryService.autoSellOldOreEnabled = true;
-        this.inventoryService.autoSellOldBarsEnabled = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.inventoryService.autoSellOldOre = true;
+        this.services.inventoryService.autoSellOldOreEnabled = true;
+        this.services.inventoryService.autoSellOldBarsEnabled = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.autoSellOldOre;
+        return this.services.inventoryService.autoSellOldOre;
       }
     },
     bestHidesManual: {
@@ -2172,20 +1909,12 @@ export class ItemRepoService {
       useDescription: "Permanently unlock auto-selling lower grade hides.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.autoSellOldHides = true;
-        this.inventoryService.autoSellOldHidesEnabled = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.inventoryService.autoSellOldHides = true;
+        this.services.inventoryService.autoSellOldHidesEnabled = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.autoSellOldHides;
+        return this.services.inventoryService.autoSellOldHides;
       }
     },
     bestWeaponManual: {
@@ -2198,19 +1927,11 @@ export class ItemRepoService {
       useDescription: "Permanently unlock auto-equipping the best weapons in your inventory.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.autoequipBestWeapon = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.inventoryService.autoequipBestWeapon = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.autoequipBestWeapon;
+        return this.services.inventoryService.autoequipBestWeapon;
       }
     },
     bestArmorManual: {
@@ -2223,19 +1944,11 @@ export class ItemRepoService {
       useDescription: "Permanently unlock auto-equipping the best armor in your inventory.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.autoequipBestArmor = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.inventoryService.autoequipBestArmor = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.autoequipBestArmor;
+        return this.services.inventoryService.autoequipBestArmor;
       }
     },
     betterStorageManual: {
@@ -2248,19 +1961,11 @@ export class ItemRepoService {
       useDescription: "Permanently increase by ten times the number of items you can put in each stack in your inventory.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.maxStackSize *= 10;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.inventoryService.maxStackSize *= 10;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.maxStackSize >= 1000;
+        return this.services.inventoryService.maxStackSize >= 1000;
       }
     },
     evenBetterStorageManual: {
@@ -2273,19 +1978,11 @@ export class ItemRepoService {
       useDescription: "Permanently increase by ten times the number of items you can put in each stack in your inventory.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.maxStackSize *= 10;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.inventoryService.maxStackSize *= 10;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.maxStackSize >= 10000;
+        return this.services.inventoryService.maxStackSize >= 10000;
       }
     },
     bestStorageManual: {
@@ -2298,19 +1995,11 @@ export class ItemRepoService {
       useDescription: "Permanently increase by ten times the number of items you can put in each stack in your inventory.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.maxStackSize *= 10;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.inventoryService.maxStackSize *= 10;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.maxStackSize >= 100000;
+        return this.services.inventoryService.maxStackSize >= 100000;
       }
     },
     followerAutoDismissManual: {
@@ -2323,19 +2012,11 @@ export class ItemRepoService {
       useDescription: "Permanently increase by ten times the number of items you can put in each stack in your inventory.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.followerService) {
-          this.followerService = this.injector.get(FollowersService);
-        }
-        this.followerService.autoDismissUnlocked = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.followerService.autoDismissUnlocked = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.followerService) {
-          this.followerService = this.injector.get(FollowersService);
-        }
-        return this.followerService.autoDismissUnlocked;
+        return this.services.followerService.autoDismissUnlocked;
       }
     },
     bestGemsManual: {
@@ -2348,20 +2029,12 @@ export class ItemRepoService {
       useDescription: "Permanently unlock gem auto-selling for lower level gems.",
       useConsumes: true,
       use: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        this.inventoryService.autoSellOldGemsUnlocked = true;
-        this.inventoryService.autoSellOldGemsEnabled = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.inventoryService.autoSellOldGemsUnlocked = true;
+        this.services.inventoryService.autoSellOldGemsEnabled = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        // check if inventoryService is injected yet, if not, inject it (circular dependency issues)
-        if (!this.inventoryService) {
-          this.inventoryService = this.injector.get(InventoryService);
-        }
-        return this.inventoryService.autoSellOldGemsUnlocked;
+        return this.services.inventoryService.autoSellOldGemsUnlocked;
       }
     },
     autoPauseSettingsManual: {
@@ -2374,17 +2047,11 @@ export class ItemRepoService {
       useDescription: "Permanently unlock auto-pausing customization",
       useConsumes: true,
       use: () => {
-        if (!this.activityService) {
-          this.activityService = this.injector.get(ActivityService);
-        }
-        this.activityService.autoPauseUnlocked = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.activityService.autoPauseUnlocked = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        if (!this.activityService) {
-          this.activityService = this.injector.get(ActivityService);
-        }
-        return this.activityService.autoPauseUnlocked;
+        return this.services.activityService.autoPauseUnlocked;
       }
     },
     bankedTicksEfficiencyManual: {
@@ -2397,11 +2064,11 @@ export class ItemRepoService {
       useDescription: "Permanently increase banked tick efficiency to 50%.",
       useConsumes: true,
       use: () => {
-        this.mainLoopService.offlineDivider = 2;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.mainLoopService.offlineDivider = 2;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        return this.mainLoopService.offlineDivider <= 2;
+        return this.services.mainLoopService.offlineDivider <= 2;
       }
     },
     autoRestManual: {
@@ -2414,17 +2081,11 @@ export class ItemRepoService {
       useDescription: "Permanently unlock automatic resting.",
       useConsumes: true,
       use: () => {
-        if (!this.activityService) {
-          this.activityService = this.injector.get(ActivityService);
-        }
-        this.activityService.autoRestUnlocked = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.activityService.autoRestUnlocked = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        if (!this.activityService) {
-          this.activityService = this.injector.get(ActivityService);
-        }
-        return this.activityService.autoRestUnlocked;
+        return this.services.activityService.autoRestUnlocked;
       }
     },
     ageSpeedManual: {
@@ -2437,11 +2098,11 @@ export class ItemRepoService {
       useDescription: "Permanently increase time passage based on your age.",
       useConsumes: true,
       use: () => {
-        this.mainLoopService.unlockAgeSpeed = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.mainLoopService.unlockAgeSpeed = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        return this.mainLoopService.unlockAgeSpeed;
+        return this.services.mainLoopService.unlockAgeSpeed;
       }
     },
     totalPlaytimeManual: {
@@ -2454,20 +2115,24 @@ export class ItemRepoService {
       useDescription: "Permanently increase time passage based on your total time lived.",
       useConsumes: true,
       use: () => {
-        this.mainLoopService.unlockPlaytimeSpeed = true;
-        this.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
+        this.services.mainLoopService.unlockPlaytimeSpeed = true;
+        this.services.logService.addLogMessage("The teachings of the manual sink deep into your soul. You'll be able to apply this knowledge in all future reincarnations.", "STANDARD", 'EVENT');
       },
       owned: () => {
-        return this.mainLoopService.unlockPlaytimeSpeed;
+        return this.services.mainLoopService.unlockPlaytimeSpeed;
       }
     },
   }
+}
 
-  constructor(private characterService: CharacterService,
-    private injector: Injector,
-    private logService: LogService,
-    private mainLoopService: MainLoopService) {
+  constructor(private services: ServicesService) {
 
+  }
+
+  init(): ItemRepoService {
+    this.populateFurniture();
+    this.populateItems();
+    return this;
   }
 
   getItemById(id: string): Item | undefined {

--- a/src/app/game-state/log.service.ts
+++ b/src/app/game-state/log.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
-import { isEmpty } from 'rxjs';
-import { MainLoopService } from './main-loop.service';
+import { ServicesService } from './services.service';
 
 const LOG_MERGE_INTERVAL_MS = 1000;
 export type LogType = 'STANDARD' | 'INJURY';
@@ -37,16 +36,18 @@ export class LogService {
   currentLog: Log[] = [];
 
   constructor(
+    private services: ServicesService
+  ) {}
 
-    mainLoopService: MainLoopService
-  ) {
-    mainLoopService.frameSubject.subscribe(() => {
+  init(): LogService {
+    this.services.mainLoopService.frameSubject.subscribe(() => {
       this.updateLogTopics();
     });
     this.addLogMessage("Once in a very long while, a soul emerges from the chaos that is destined for immortality. You are such a soul.", 'STANDARD', 'STORY');
     this.addLogMessage("Your journey to immortality begins as a humble youth leaves home to experience the world. Choose the activities that will help you cultivate the attributes of an immortal.", 'STANDARD', 'STORY');
     this.addLogMessage("It may take you many reincarnations before you achieve your goals, but with each new life you will rise with greater aptitudes that allow you to learn and grow faster.", 'STANDARD', 'STORY');
     this.addLogMessage("Be careful, the world can be a dangerous place.", 'STANDARD', 'STORY');
+    return this;
   }
 
   addLogMessage(message: string, type: LogType, topic: LogTopic): void {

--- a/src/app/game-state/main-loop.service.ts
+++ b/src/app/game-state/main-loop.service.ts
@@ -1,10 +1,9 @@
 
-import { Injectable, Injector } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
-//import { threadId } from 'worker_threads';
-import { CharacterService } from './character.service';
 import { MatDialog } from '@angular/material/dialog';
 import { OfflineModalComponent } from '../offline-modal/offline-modal.component';
+import { ServicesService } from './services.service';
 
 const TICK_INTERVAL_MS = 25;
 const LONG_TICK_INTERVAL_MS = 500;
@@ -48,15 +47,14 @@ export class MainLoopService {
   lastTime: number = new Date().getTime();
   bankedTicks = 0;
   offlineDivider = 10;
-  characterService?: CharacterService;
   useBankedTicks = true;
   scientificNotation = false;
   earnedTicks = 0;
 
   constructor(
-    private injector: Injector,
-    public dialog: MatDialog) {
-  }
+    private services: ServicesService,
+    public dialog: MatDialog
+  ) {}
 
   getProperties(): MainLoopProperties {
     return {
@@ -109,10 +107,6 @@ export class MainLoopService {
   }
 
   start() {
-    if (!this.characterService) {
-      this.characterService = this.injector.get(CharacterService);
-    }
-
     window.setInterval(() => {
       this.longTickSubject.next(true);
     }, LONG_TICK_INTERVAL_MS);
@@ -172,9 +166,9 @@ export class MainLoopService {
 
   getTPS(div: number) {
     let ticksPassed = 1000 / TICK_INTERVAL_MS;
-    if (this.characterService && this.unlockAgeSpeed && this.tickDivider < 40) { // don't do this on slow speed
+    if (this.services.characterService && this.unlockAgeSpeed && this.tickDivider < 40) { // don't do this on slow speed
       // 73000 is 200 years. reaches 2x at 600 years, 3x at 1600, 4x at 3000. Caps at 12600
-      ticksPassed *= Math.min(8, Math.sqrt(1 + this.characterService.characterState.age / 73000));
+      ticksPassed *= Math.min(8, Math.sqrt(1 + this.services.characterService.characterState.age / 73000));
     }
     if (this.unlockPlaytimeSpeed && this.tickDivider < 40) { // don't do this on slow speed
       ticksPassed *= Math.pow(1 + this.totalTicks / (2000 * 365), 0.3);

--- a/src/app/game-state/services.service.ts
+++ b/src/app/game-state/services.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, Injector } from '@angular/core';
+import { AchievementService } from './achievement.service';
+import { ActivityService } from './activity.service';
+import { AutoBuyerService } from './autoBuyer.service';
+import { BattleService } from './battle.service';
+import { CharacterService } from './character.service';
+import { FollowersService } from './followers.service';
+import { GameStateService } from './game-state.service';
+import { HellService } from './hell.service';
+import { HomeService } from './home.service';
+import { ImpossibleTaskService } from './impossibleTask.service';
+import { InventoryService } from './inventory.service';
+import { ItemRepoService } from './item-repo.service';
+import { LogService } from './log.service';
+import { MainLoopService } from './main-loop.service';
+import { ReincarnationService } from './reincarnation.service';
+import { StoreService } from './store.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ServicesService {
+  public achievementService!: AchievementService;
+  public activityService!: ActivityService;
+  public autoBuyerService!: AutoBuyerService;
+  public battleService!: BattleService;
+  public characterService!: CharacterService;
+  public followerService!: FollowersService;
+  public gameStateService!: GameStateService;
+  public hellService!: HellService;
+  public homeService!: HomeService;
+  public impossibleTaskService!: ImpossibleTaskService;
+  public inventoryService!: InventoryService;
+  public itemRepoService!: ItemRepoService;
+  public logService!: LogService;
+  public mainLoopService!: MainLoopService;
+  public reincarnationService!: ReincarnationService;
+  public storeService!: StoreService;
+
+  constructor(private injector: Injector) {}
+
+  init(): void {
+    this.mainLoopService = this.injector.get(MainLoopService);
+    this.logService = this.injector.get(LogService).init();
+    this.reincarnationService = this.injector.get(ReincarnationService);
+    this.characterService = this.injector.get(CharacterService).init();
+    this.itemRepoService = this.injector.get(ItemRepoService).init();
+    this.achievementService = this.injector.get(AchievementService).init();
+    this.activityService = this.injector.get(ActivityService).init();
+    this.battleService = this.injector.get(BattleService).init();
+    this.followerService = this.injector.get(FollowersService).init();
+    this.gameStateService = this.injector.get(GameStateService).init();
+    this.hellService = this.injector.get(HellService).init();
+    this.inventoryService = this.injector.get(InventoryService).init();
+    this.homeService = this.injector.get(HomeService).init();
+    this.impossibleTaskService = this.injector.get(ImpossibleTaskService).init();
+    this.storeService = this.injector.get(StoreService);
+    this.autoBuyerService = this.injector.get(AutoBuyerService).init();
+  }
+}

--- a/src/app/game-state/store.service.ts
+++ b/src/app/game-state/store.service.ts
@@ -1,50 +1,42 @@
 import { Injectable } from '@angular/core';
-import { LogService } from './log.service';
-import { CharacterService } from '../game-state/character.service';
-import { Furniture, InventoryService, Item, instanceOfFurniture } from '../game-state/inventory.service';
-import { HomeService, HomeType, Home } from '../game-state/home.service';
-import { ItemRepoService } from '../game-state/item-repo.service';
+import { Furniture, Item, instanceOfFurniture } from '../game-state/inventory.service';
+import { HomeType, Home } from '../game-state/home.service';
 import { MatDialog } from '@angular/material/dialog';
+import { ServicesService } from './services.service';
 
 @Injectable({
   providedIn: 'root'
 })
 
 export class StoreService {
-  manuals: Item[];
-  furniture: Furniture[];
-  selectedItem: Item | null;
+  manuals: Item[] = [];
+  furniture: Furniture[] = [];
+  selectedItem: Item | null = null;
   soulCoreRank = 0;
   meridianRank = 0;
   bloodlineLabel = "";
   bloodlineDescription = "";
-  bloodLineHomeRequirement: Home = this.homeService.homesList[HomeType.Palace];
+  bloodLineHomeRequirement!: Home;
   storeOpened = false;
   furniturePrices: { [key: string]: number; } = {};
 
   constructor(
-    private logService: LogService,
-    private characterService: CharacterService,
-    private inventoryService: InventoryService,
-    private itemRepoService: ItemRepoService,
-    public homeService: HomeService,
+    private services: ServicesService,
     public dialog: MatDialog
-  ) {
-    this.selectedItem = null;
+  ) {}
 
-    this.manuals = [];
-    this.furniture = [];
-
-
+  init(): StoreService {
+    this.bloodLineHomeRequirement = this.services.homeService.homesList[HomeType.Palace];
+    return this;
   }
 
   setStoreInventory() {
     this.furniture = [];
-    for (const key in this.itemRepoService.furniture) {
-      const furniture = this.itemRepoService.furniture[key];
-      if (this.homeService.home.furnitureSlots.includes(furniture.slot)) {
+    for (const key in this.services.itemRepoService.furniture) {
+      const furniture = this.services.itemRepoService.furniture[key];
+      if (this.services.homeService.home.furnitureSlots.includes(furniture.slot)) {
         this.furniture.push(furniture);
-        if (this.homeService.ownedFurniture.includes(furniture.name)) {
+        if (this.services.homeService.ownedFurniture.includes(furniture.name)) {
           this.furniturePrices[furniture.name] = 0;
         } else {
           this.furniturePrices[furniture.name] = furniture.value;
@@ -63,13 +55,13 @@ export class StoreService {
 
   buyManual() {
     if (this.selectedItem) {
-      if (this.selectedItem.value < this.characterService.characterState.money) {
-        this.characterService.characterState.money -= this.selectedItem.value;
+      if (this.selectedItem.value < this.services.characterService.characterState.money) {
+        this.services.characterService.characterState.money -= this.selectedItem.value;
         if (this.selectedItem.type === 'manual' && this.selectedItem.use) {
           // use manuals immediately
           this.selectedItem.use();
         } else {
-          this.inventoryService.addItem(this.selectedItem);
+          this.services.inventoryService.addItem(this.selectedItem);
         }
       }
     }
@@ -98,64 +90,64 @@ export class StoreService {
         return;
       }
       const slot = item.slot;
-      if (item.value < this.characterService.characterState.money || this.homeService.ownedFurniture.includes(item.name)) {
-        if (!this.homeService.ownedFurniture.includes(item.name)) {
+      if (item.value < this.services.characterService.characterState.money || this.services.homeService.ownedFurniture.includes(item.name)) {
+        if (!this.services.homeService.ownedFurniture.includes(item.name)) {
           // only pay for it once per lifetime
-          this.characterService.characterState.money -= item.value;
-          this.homeService.ownedFurniture.push(item.name);
+          this.services.characterService.characterState.money -= item.value;
+          this.services.homeService.ownedFurniture.push(item.name);
           this.furniturePrices[item.name] = 0;
         }
-        this.homeService.furniture[slot] = item;
-        this.homeService.autoBuyFurniture[slot] = item;
+        this.services.homeService.furniture[slot] = item;
+        this.services.homeService.autoBuyFurniture[slot] = item;
       }
     }
   }
 
   updateAscensions() {
-    this.soulCoreRank = this.characterService.soulCoreRank();
-    this.meridianRank = this.characterService.meridianRank();
-    if (this.characterService.characterState.bloodlineRank === 0) {
+    this.soulCoreRank = this.services.characterService.soulCoreRank();
+    this.meridianRank = this.services.characterService.meridianRank();
+    if (this.services.characterService.characterState.bloodlineRank === 0) {
       this.bloodlineLabel = "Establish Bloodline";
     } else {
       this.bloodlineLabel = "Enhance Bloodline";
     }
-    if (this.characterService.characterState.bloodlineRank === 0) {
+    if (this.services.characterService.characterState.bloodlineRank === 0) {
       // Weapons
       this.bloodlineDescription = "End your current life, sacrifice all attributes and aptitudes that are not protected by the power of your previous soul core ascensions, and establish a bloodline. All of your future reincarnations will be born as your own descendants. Your weapons equipped on death will become family heirlooms and will be inherited by your future self.";
-      this.bloodLineHomeRequirement = this.homeService.homesList[HomeType.Mansion];
-    } else if (this.characterService.characterState.bloodlineRank === 1) {
+      this.bloodLineHomeRequirement = this.services.homeService.homesList[HomeType.Mansion];
+    } else if (this.services.characterService.characterState.bloodlineRank === 1) {
       // Armor
       this.bloodlineDescription = "End your current life, sacrifice all attributes and aptitudes that are not protected by the power of your previous soul core ascensions, and enhance your bloodline. Your armor and your weapons equipped on death will become family heirlooms and will be inherited by your future self.";
-      this.bloodLineHomeRequirement = this.homeService.homesList[HomeType.Palace];
-    } else if (this.characterService.characterState.bloodlineRank === 2) {
+      this.bloodLineHomeRequirement = this.services.homeService.homesList[HomeType.Palace];
+    } else if (this.services.characterService.characterState.bloodlineRank === 2) {
       // Inherit Money
       this.bloodlineDescription = "End your current life, sacrifice all attributes and aptitudes that are not protected by the power of your previous soul core ascensions, and enhance your bloodline. Your armor and your weapons equipped on death will become family heirlooms and will be inherited by your future self. You will also inherit some of your past self's money.";
-      this.bloodLineHomeRequirement = this.homeService.homesList[HomeType.Castle];
-    } else if (this.characterService.characterState.bloodlineRank === 3) {
+      this.bloodLineHomeRequirement = this.services.homeService.homesList[HomeType.Castle];
+    } else if (this.services.characterService.characterState.bloodlineRank === 3) {
       // Interest
       this.bloodlineDescription = "End your current life, sacrifice all attributes and aptitudes that are not protected by the power of your previous soul core ascensions, and enhance your bloodline. Your armor and your weapons equipped on death will become family heirlooms and will be inherited by your future self. You will also inherit your past self's money plus interest.";
-      this.bloodLineHomeRequirement = this.homeService.homesList[HomeType.Fortress];
-    } else if (this.characterService.characterState.bloodlineRank === 4) {
+      this.bloodLineHomeRequirement = this.services.homeService.homesList[HomeType.Fortress];
+    } else if (this.services.characterService.characterState.bloodlineRank === 4) {
       // Basic Stat Lifespan
       this.bloodlineDescription = "End your current life, sacrifice all attributes and aptitudes that are not protected by the power of your previous soul core ascensions, and enhance your bloodline. Your armor and your weapons equipped on death will become family heirlooms and will be inherited by your future self. You will also inherit your past self's money plus interest. Your aptitudes extend your lifespan to a much greater degree.";
-      this.bloodLineHomeRequirement = this.homeService.homesList[HomeType.Mountain];
-    } else if (this.characterService.characterState.bloodlineRank === 5) {
+      this.bloodLineHomeRequirement = this.services.homeService.homesList[HomeType.Mountain];
+    } else if (this.services.characterService.characterState.bloodlineRank === 5) {
       // Home
       this.bloodlineDescription = "End your current life, sacrifice all attributes and aptitudes that are not protected by the power of your previous soul core ascensions, and enhance your bloodline. You will keep your ancestral Home. You will keep your weapons, armor, and money with interest. ";
-      this.bloodLineHomeRequirement = this.homeService.homesList[HomeType.ForbiddenCity];
-    } else if (this.characterService.characterState.bloodlineRank === 6) {
+      this.bloodLineHomeRequirement = this.services.homeService.homesList[HomeType.ForbiddenCity];
+    } else if (this.services.characterService.characterState.bloodlineRank === 6) {
       // Entourage
       this.bloodlineDescription = "End your current life, sacrifice all attributes and aptitudes that are not protected by the power of your previous soul core ascensions, and enhance your bloodline. Your followers will have enhanced bloodlines and will follow you between incarnations. You will keep your weapons, armor, money with interest, your home and your Empire.";
-      this.bloodLineHomeRequirement = this.homeService.homesList[HomeType.Capital];
-    } else if (this.characterService.characterState.bloodlineRank === 7) {
+      this.bloodLineHomeRequirement = this.services.homeService.homesList[HomeType.Capital];
+    } else if (this.services.characterService.characterState.bloodlineRank === 7) {
       // Limit Break
       this.bloodlineDescription = "End your current life, sacrifice all attributes and aptitudes that are not protected by the power of your previous soul core ascensions, and enhance your bloodline. Break through the limits of humanity. You will keep your weapons, armor, money with interest, your home, and your Empire.";
-      this.bloodLineHomeRequirement = this.homeService.homesList[HomeType.ImperialSeat];
-    } else if (this.characterService.characterState.bloodlineRank === 8) {
+      this.bloodLineHomeRequirement = this.services.homeService.homesList[HomeType.ImperialSeat];
+    } else if (this.services.characterService.characterState.bloodlineRank === 8) {
       // Daily Aptitude Increase
       this.bloodlineDescription = "End your current life, sacrifice all attributes and aptitudes that are not protected by the power of your previous soul core ascensions, and enhance your bloodline one last time. Finally, you will gain aptitudes every day from your current Attributes, improving constantly. You will keep your weapons, armor, money with interest, your home, and your Empire.";
-      this.bloodLineHomeRequirement = this.homeService.homesList[HomeType.Godthrone];
-    } else if (this.characterService.characterState.bloodlineRank === 9) {
+      this.bloodLineHomeRequirement = this.services.homeService.homesList[HomeType.Godthrone];
+    } else if (this.services.characterService.characterState.bloodlineRank === 9) {
       this.bloodlineDescription = "You can't enhance your bloodline any further. Your armor and your weapons equipped on death will become family heirlooms and will be inherited by your future self. You will also inherit your past self's money plus interest. Your aptitudes extend your lifespan to a much greater degree. Your followers also have enhanced bloodlines and will follow you between incarnations. You will keep your Home and your Empire, and can break through the limits of humanity. Finally, you will gain aptitudes every day from your current Attributes.";
     }
 
@@ -163,53 +155,53 @@ export class StoreService {
 
   condenseSoulCore() {
     if (this.soulCoreRank >= 9) {
-      this.logService.addLogMessage("You can't condense your soul core any further.", "INJURY", "EVENT");
+      this.services.logService.addLogMessage("You can't condense your soul core any further.", "INJURY", "EVENT");
       return;
     }
-    if (this.characterService.characterState.attributes.spirituality.value < this.characterService.characterState.condenseSoulCoreCost) {
-      this.logService.addLogMessage("You don't have the spirituality required to ascend.", "INJURY", "EVENT");
+    if (this.services.characterService.characterState.attributes.spirituality.value < this.services.characterService.characterState.condenseSoulCoreCost) {
+      this.services.logService.addLogMessage("You don't have the spirituality required to ascend.", "INJURY", "EVENT");
       return;
     }
-    if (this.inventoryService.checkFor("spiritGem") < (this.soulCoreRank + 12) * 10) {
-      this.logService.addLogMessage("You don't have the gem required to ascend.", "INJURY", "EVENT");
+    if (this.services.inventoryService.checkFor("spiritGem") < (this.soulCoreRank + 12) * 10) {
+      this.services.logService.addLogMessage("You don't have the gem required to ascend.", "INJURY", "EVENT");
       return;
     }
-    this.characterService.condenseSoulCore();
+    this.services.characterService.condenseSoulCore();
     this.dialog.closeAll();
   }
 
   reinforceMeridians() {
     if (this.meridianRank >= 9) {
-      this.logService.addLogMessage("You can't reinforce your meridians any further.", "INJURY", "EVENT");
+      this.services.logService.addLogMessage("You can't reinforce your meridians any further.", "INJURY", "EVENT");
       return;
     }
-    if (this.characterService.characterState.attributes.spirituality.value < this.characterService.characterState.reinforceMeridiansCost) {
-      this.logService.addLogMessage("You don't have the spirituality required to ascend.", "INJURY", "EVENT");
+    if (this.services.characterService.characterState.attributes.spirituality.value < this.services.characterService.characterState.reinforceMeridiansCost) {
+      this.services.logService.addLogMessage("You don't have the spirituality required to ascend.", "INJURY", "EVENT");
       return;
     }
-    if (this.inventoryService.checkFor("spiritGem") < (this.meridianRank + 16) * 10) {
-      this.logService.addLogMessage("You don't have the gem required to ascend.", "INJURY", "EVENT");
+    if (this.services.inventoryService.checkFor("spiritGem") < (this.meridianRank + 16) * 10) {
+      this.services.logService.addLogMessage("You don't have the gem required to ascend.", "INJURY", "EVENT");
       return;
     }
 
-    this.characterService.reinforceMeridians();
+    this.services.characterService.reinforceMeridians();
     this.dialog.closeAll();
   }
 
   upgradeBloodline() {
-    if (this.characterService.characterState.attributes.spirituality.value < this.characterService.characterState.bloodlineCost) {
-      this.logService.addLogMessage("You don't have the spirituality required to ascend.", "INJURY", "EVENT");
+    if (this.services.characterService.characterState.attributes.spirituality.value < this.services.characterService.characterState.bloodlineCost) {
+      this.services.logService.addLogMessage("You don't have the spirituality required to ascend.", "INJURY", "EVENT");
       return;
     }
-    if (this.characterService.characterState.bloodlineRank >= 9) {
-      this.logService.addLogMessage("You can't enhance your bloodline any further.", "INJURY", "EVENT");
+    if (this.services.characterService.characterState.bloodlineRank >= 9) {
+      this.services.logService.addLogMessage("You can't enhance your bloodline any further.", "INJURY", "EVENT");
       return;
     }
-    if (this.homeService.home.type < this.bloodLineHomeRequirement.type) {
-      this.logService.addLogMessage("You don't have a powerful enough home to ascend.", "INJURY", "EVENT");
+    if (this.services.homeService.home.type < this.bloodLineHomeRequirement.type) {
+      this.services.logService.addLogMessage("You don't have a powerful enough home to ascend.", "INJURY", "EVENT");
       return;
     }
-    this.characterService.upgradeBloodline();
+    this.services.characterService.upgradeBloodline();
     this.dialog.closeAll();
   }
 

--- a/src/app/inventory-panel/inventory-panel.component.ts
+++ b/src/app/inventory-panel/inventory-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CharacterService } from '../game-state/character.service';
 import { EquipmentPosition } from '../game-state/character'
 import { InventoryService, ItemStack, Item, instanceOfEquipment } from '../game-state/inventory.service';
@@ -11,17 +11,18 @@ import { MainLoopService } from '../game-state/main-loop.service';
   styleUrls: ['./inventory-panel.component.less', '../app.component.less']
 })
 
-export class InventoryPanelComponent {
-  equipmentSlots: string[];
+export class InventoryPanelComponent implements OnInit {
+  equipmentSlots: string[] = [];
   instanceOfEquipment =  instanceOfEquipment;
 
   constructor(public inventoryService: InventoryService,
     public characterService: CharacterService,
     public hellService: HellService,
     public mainLoopService: MainLoopService
-    ) {
-      this.equipmentSlots = Object.keys(this.characterService.characterState.equipment);
+    ) {}
 
+  ngOnInit(): void {
+    this.equipmentSlots = Object.keys(this.characterService.characterState.equipment);
   }
 
   isFinite(value: number){

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "importHelpers": true,
     "target": "es2017",
     "module": "es2020",
-    "types": ["node"],
+    "types": ["node", "jasmine"],
     "lib": [
       "es2020",
       "dom"


### PR DESCRIPTION
Bear with me on this one. This code may seem silly, but it's the first step in a process to untangle some of the code.

The services in game-state are tied together in quite the confusing manner with special handling in several of them to avoid potential circular dependencies. By moving references to all the services to a single service class we can centralize all the uses of Injector, which long term will give code that's more loosely coupled and easier to maintain.

I wouldn't mind merging this to another branch until all the pieces are complete. That way we don't end up deciding this is all a pointless endeavor in the middle of a conversion and we could just toss the branch.