### PR TITLE
remove bankedCycle flicker when space is held

### DIFF
--- a/src/app/time-panel/time-panel.component.html
+++ b/src/app/time-panel/time-panel.component.html
@@ -43,7 +43,7 @@
       settings
     </mat-icon>
 
-    <h6 *ngIf="mainLoopService.bankedTicks > 0">
+    <h6 *ngIf="mainLoopService.bankedTicks > 1">
       <input type="checkbox" (change)="useSavedTicks($event)" id="useSavedTicks"
         [checked]="mainLoopService.useBankedTicks"/>
       <label for="useSavedTicks">Use banked time to accelerate reality (10x). {{mainLoopService.bankedTicks | number: '1.0-0'}} time ticks left.</label>


### PR DESCRIPTION
when space is held and the bankedCycles are used up the game switches between pause and the last speed setting
creating a situation where the bankedCycles element repeatedly gets drawn and not

the change sets the bankedCycles check to >1 from my testing (rather early save) thats enough to prevent the flicker

before:
https://github.com/immortalityidle/immortalityidle.github.io/assets/115591472/72652b1c-f284-46b5-94c7-f470e1664be7

after:
https://github.com/immortalityidle/immortalityidle.github.io/assets/115591472/d11ef153-8f1a-49cc-b4f0-d9966efd0332




